### PR TITLE
Add logic for adding adjacent neighbors in time

### DIFF
--- a/hera_opm/data/sample_config/nrao_rtp_time_neighbors.cfg
+++ b/hera_opm/data/sample_config/nrao_rtp_time_neighbors.cfg
@@ -30,11 +30,11 @@ args = {basename}, ${Options:ex_ants}
 [OMNICAL_METRICS]
 prereqs = OMNICAL
 time_prereqs = OMNICAL
-args = {basename}
+args = {basename} {prev_basename} {next_basename}
 
 [OMNI_APPLY]
 prereqs = OMNICAL_METRICS
-args = {basename} {prev_basename} {next_basename}
+args = {basename}
 
 [XRFI]
 args = {basename}

--- a/hera_opm/data/sample_config/nrao_rtp_time_neighbors.cfg
+++ b/hera_opm/data/sample_config/nrao_rtp_time_neighbors.cfg
@@ -1,0 +1,71 @@
+# This is a sample configuration for reanalysis steps at NRAO. Note that
+# specifications exist for steps not in the actions list. Though not necessary,
+# these are not harmful either.
+
+[Options]
+pols = xx,xy,yx,yy
+path_to_do_scripts = ~/hera/hera_op/hera_op/data/sample_task_scripts
+conda_env = hera
+ex_ants = ~/hera/hera_cal/hera_cal/calibrations/herahex_ex_ants.txt
+base_mem = 10000
+base_cpu = 1
+
+[WorkFlow]
+actions = ANT_METRICS, FIRSTCAL, FIRSTCAL_METRICS, OMNICAL, OMNICAL_METRICS,
+          OMNI_APPLY, XRFI, XRFI_APPLY
+
+[ANT_METRICS]
+args = {basename}
+
+[FIRSTCAL]
+args = {basename}, ${Options:ex_ants}
+
+[FIRSTCAL_METRICS]
+args = {basename}
+
+[OMNICAL]
+prereqs = FIRSTCAL_METRICS
+args = {basename}, ${Options:ex_ants}
+
+[OMNICAL_METRICS]
+prereqs = OMNICAL
+time_prereqs = OMNICAL
+args = {basename}
+
+[OMNI_APPLY]
+prereqs = OMNICAL_METRICS
+args = {basename} {prev_basename} {next_basename}
+
+[XRFI]
+args = {basename}
+
+[XRFI_APPLY]
+prereqs = XRFI
+args = {basename}
+
+[CLEAN_SUBARRAY]
+prereqs = XRFI_APPLY
+args = {basename}
+
+[CLEAN_ANT_METRICS]
+args = {basename}
+
+[CLEAN_FIRSTCAL]
+prereqs = OMNICAL
+args = {basename}
+
+[CLEAN_FIRSTCAL_METRICS]
+args = {basename}
+
+[CLEAN_OMNICAL]
+prereqs = XRFI_APPLY
+args = {basename}
+
+[CLEAN_OMNICAL_METRICS]
+args = {basename}
+
+[CLEAN_OMNI_APPLY]
+args = {basename}
+
+[CLEAN_XRFI]
+args = {basename}

--- a/hera_opm/mf_tools.py
+++ b/hera_opm/mf_tools.py
@@ -70,7 +70,68 @@ def make_outfile_name(obsid, action, pol_list=[]):
     return outfiles
 
 
-def prep_args(args, obsid, pol):
+def make_time_neighbor_outfile_name(obsid, action, obsids, pol=None):
+    '''
+    Make a list of neighbors in time for prereqs.
+
+    Args:
+    ====================
+    obsid (str) -- obsid of the current file
+    action (str) -- the action corresponding to the time prereqs
+    obsids -- list of all obsids for the given day; uses this list (sorted) to
+        define neighbors
+    pol (str) -- if present, polarization string to substitute into obsid
+
+    Returns:
+    ====================
+    outfiles -- a list of files for time-adjacent neighbors.
+    '''
+    outfiles = []
+
+    # find the neighbors of current obsid in list of obsids
+    obsids = sorted(obsids)
+    try:
+        obs_idx = obsids.index(obsid)
+    except ValueError:
+        raise ValueError("obsid {} not found in list of obsids".format(obsid))
+
+    # extract adjacent neighbors, if not on the end
+    if obs_idx > 0:
+        prev_obsid = obsids[obs_idx - 1]
+    else:
+        prev_obsid = None
+    if obs_idx < len(obsids) - 2:
+        next_obsid = obsids[obs_idx + 1]
+    else:
+        next_obsid = None
+
+    if pol is not None:
+        # replace polarization string in obsid with pol
+        match = re.search(r'zen\.\d{7}\.\d{5}\.(.+)\.', obsid)
+        if match:
+            obs_pol = match.group(1)
+            basename = re.sub(obs_pol, pol, obsid)
+            if prev_obsid is not None:
+                prev_obsid = re.sub(obs_pol, pol, prev_obsid)
+                of = "{0}.{1}.{2}.out".format(prev_obsid, action, pol)
+                outfiles.append(of)
+            if next_obsid is not None:
+                next_obsid = re.sub(obs_pol, pol, next_obsid)
+                of = "{0}.{1}.{2}.out".format(next_obsid, action, pol)
+                outfiles.append(next_obsid)
+        else:
+            raise ValueError("Could not extract polarization string from obsid {}".format(obsid))
+    else:
+        if prev_obsid is not None:
+            of = "{0}.{1}.out".format(prev_obsid, action)
+            outfiles.append(of)
+        if next_obsid is not None:
+            of = "{0}.{1}.out".format(next_obsid, action)
+            outfiles.append(of)
+    return outfiles
+
+
+def prep_args(args, obsid, pol=None):
     '''
     Substitute the polarization string in a filename/obsid with the specified one.
 
@@ -85,15 +146,19 @@ def prep_args(args, obsid, pol):
     ====================
     output (str) -- `args` string with mini-language and polarization substitutions.
     '''
-    # replace pol if present
-    match = re.search(r'zen\.\d{7}\.\d{5}\.(.+)\.', obsid)
-    if match:
-        obs_pol = match.group(1)
-        basename = re.sub(obs_pol, pol, obsid)
+    if pol is not None:
+        # replace pol if present
+        match = re.search(r'zen\.\d{7}\.\d{5}\.(.+)\.', obsid)
+        if match:
+            obs_pol = match.group(1)
+            basename = re.sub(obs_pol, pol, obsid)
+        else:
+            basename = obsid
+        # replace {basename} with actual basename
+        return re.sub(r'\{basename\}', basename, args)
     else:
         basename = obsid
-    # replace {basename} with actual basename
-    return re.sub(r'\{basename\}', basename, args)
+        return re.sub(r'\{basename\}', basename, args)
 
 
 def build_makeflow_from_config(obsids, config_file, mf_name=None, work_dir=None):
@@ -218,6 +283,24 @@ def build_makeflow_from_config(obsids, config_file, mf_name=None, work_dir=None)
                     # also replace polarization string
                     prepped_args = prep_args(args, filename, pol)
 
+                    time_prereqs = get_config_entry(config, action, "time_prereqs", required=False)
+                    if len(time_prereqs) > 0:
+                        # get a copy of the infile list; we're going to add to it, but don't want these
+                        # entries broadcast across pols
+                        infiles_pol = infiles
+                        for tp in time_prereqs:
+                            try:
+                                ip = workflow.index(tp)
+                            except ValueError:
+                                raise ValueError("Time prereq \"{0}\" for action \"{1}\" not found in main "
+                                                 "workflow".format(tp, action))
+                            tp_outfiles = make_time_neighbor_outfile_name(filename, action, pol, obsids)
+                            for of in tp_outfiles:
+                                infiles_pol.append(of)
+                    else:
+                        # just get a copy of the infiles as-is
+                        infiles_pol = infiles
+
                     # make logfile name
                     # logfile will capture stdout and stderr
                     logfile = re.sub('\.out', '.log', outfile)
@@ -245,7 +328,7 @@ def build_makeflow_from_config(obsids, config_file, mf_name=None, work_dir=None)
 
                     # first line lists target file to make (dummy output file), and requirements
                     # second line is "build rule", which runs the shell script and makes the output file
-                    line1 = "{0}: {1}".format(outfile, infiles)
+                    line1 = "{0}: {1}".format(outfile, infiles_pol)
                     line2 = "\t{0} > {1} 2>&1\n".format(wrapper_script, logfile)
                     print(line1, file=f)
                     print(line2, file=f)

--- a/hera_opm/mf_tools.py
+++ b/hera_opm/mf_tools.py
@@ -222,8 +222,11 @@ def build_makeflow_from_config(obsids, config_file, mf_name=None, work_dir=None)
     mem = 5000 (MB)
 
 
-    Mini-language for replacement:
-    basename = "zen.2458000.12345.uv"
+    Mini-language for replacement (example):
+    "{basename}" = "zen.2458000.12345.uv"
+
+    "{prev_basename}" and "{next_basename}" are previous and subsequent files adjacent to
+    "{basename}", useful for specifying prereqs in time
 
     '''
     # read in config file

--- a/hera_opm/mf_tools.py
+++ b/hera_opm/mf_tools.py
@@ -161,7 +161,7 @@ def prep_args(args, obsid, pol=None, obsids=None):
         args = re.sub(r'\{basename\}', basename, args)
 
     # also replace time-adjacent basenames if requested
-    if re.search(r'\{prev_basename\}', obsid):
+    if re.search(r'\{prev_basename\}', args):
         # check that there is an adjacent obsid to substitute
         if obsids is None:
             raise ValueError("when requesting time-adjacent obsids, obsids cannot be None")
@@ -175,7 +175,7 @@ def prep_args(args, obsid, pol=None, obsids=None):
         else:
             args = re.sub(r'\{prev_basename\}', obsids[obs_idx - 1], args)
 
-    if re.search(r'\{next_basename\}', obsid):
+    if re.search(r'\{next_basename\}', args):
         # check that there is an adjacent obsid to substitute
         if obsids is None:
             raise ValueError("when requesting time-adjacent obsids, obsids cannot be None")

--- a/hera_opm/mf_tools.py
+++ b/hera_opm/mf_tools.py
@@ -100,17 +100,16 @@ def make_time_neighbor_outfile_name(obsid, action, obsids, pol=None):
         prev_obsid = obsids[obs_idx - 1]
     else:
         prev_obsid = None
-    if obs_idx < len(obsids) - 2:
+    if obs_idx < len(obsids) - 1:
         next_obsid = obsids[obs_idx + 1]
     else:
         next_obsid = None
 
     if pol is not None:
         # replace polarization string in obsid with pol
-        match = re.search(r'zen\.\d{7}\.\d{5}\.(.+)\.', obsid)
+        match = re.search(r'zen\.\d{7}\.\d{5}\.(.*?)\.', obsid)
         if match:
             obs_pol = match.group(1)
-            basename = re.sub(obs_pol, pol, obsid)
             if prev_obsid is not None:
                 prev_obsid = re.sub(obs_pol, pol, prev_obsid)
                 of = "{0}.{1}.{2}.out".format(prev_obsid, action, pol)
@@ -118,7 +117,7 @@ def make_time_neighbor_outfile_name(obsid, action, obsids, pol=None):
             if next_obsid is not None:
                 next_obsid = re.sub(obs_pol, pol, next_obsid)
                 of = "{0}.{1}.{2}.out".format(next_obsid, action, pol)
-                outfiles.append(next_obsid)
+                outfiles.append(of)
         else:
             raise ValueError("Could not extract polarization string from obsid {}".format(obsid))
     else:
@@ -148,7 +147,7 @@ def prep_args(args, obsid, pol=None):
     '''
     if pol is not None:
         # replace pol if present
-        match = re.search(r'zen\.\d{7}\.\d{5}\.(.+)\.', obsid)
+        match = re.search(r'zen\.\d{7}\.\d{5}\.(.*?)\.', obsid)
         if match:
             obs_pol = match.group(1)
             basename = re.sub(obs_pol, pol, obsid)

--- a/hera_opm/tests/test_mf_tools.py
+++ b/hera_opm/tests/test_mf_tools.py
@@ -123,6 +123,20 @@ class TestMethods(object):
 
         return
 
+    def test_prep_args_errors(self):
+        # define args
+        obsid = self.obsids_time[0]
+        obsids = self.obsids_pol
+        args = '{basename} {prev_basename}'
+        nt.assert_raises(ValueError, mt.prep_args, args, obsid)
+        nt.assert_raises(ValueError, mt.prep_args, args, obsid, obsids=obsids)
+
+        args = '{basename} {next_basename}'
+        nt.assert_raises(ValueError, mt.prep_args, args, obsid)
+        nt.assert_raises(ValueError, mt.prep_args, args, obsid, obsids=obsids)
+
+        return
+
     def test_build_makeflow_from_config(self):
         # define args
         obsids = self.obsids_pol

--- a/hera_opm/tests/test_mf_tools.py
+++ b/hera_opm/tests/test_mf_tools.py
@@ -12,6 +12,7 @@ from configparser import ConfigParser, ExtendedInterpolation
 class TestMethods(object):
     def setUp(self):
         self.config_file = os.path.join(DATA_PATH, 'sample_config', 'nrao_rtp.cfg')
+        self.config_file_time_neighbors = os.path.join(DATA_PATH, 'sample_config', 'nrao_rtp_time_neighbors.cfg')
         self.obsids_pol = ['zen.2457698.40355.xx.HH.uvcA', 'zen.2457698.40355.xy.HH.uvcA',
                            'zen.2457698.40355.yx.HH.uvcA', 'zen.2457698.40355.yy.HH.uvcA']
         self.obsids_nopol = ['zen.2457698.40355.HH.uvcA']
@@ -94,6 +95,15 @@ class TestMethods(object):
         pol = self.pols[3]
         output = 'zen.2457698.40355.yy.HH.uvcA'
         nt.assert_equal(output, mt.prep_args(args, obsid, pol))
+
+        # test requesting polarization, but none found in file
+        obsid = 'zen.2457698.40355.uv'
+        nt.assert_equal(obsid, mt.prep_args(args, obsid, pol))
+
+        # test not requesting polarization
+        obsid = self.obsids_pol[0]
+        output = 'zen.2457698.40355.xx.HH.uvcA'
+        nt.assert_equal(output, mt.prep_args(args, obsid))
         return
 
     def test_build_makeflow_from_config(self):
@@ -134,6 +144,37 @@ class TestMethods(object):
         mt.build_makeflow_from_config(obsids, config_file, mf_name=outfile, work_dir=work_dir)
 
         nt.assert_true(os.path.exists(outfile))
+
+        # clean up after ourselves
+        os.remove(outfile)
+        mt.clean_wrapper_scripts(work_dir)
+
+        return
+
+    def test_build_makeflow_from_config_time_neighbors(self):
+        # define args
+        obsids = self.obsids_time
+        config_file = self.config_file_time_neighbors
+        work_dir = os.path.join(DATA_PATH, 'test_output')
+
+        mf_output = os.path.splitext(os.path.basename(config_file))[0] + '.mf'
+        outfile = os.path.join(work_dir, mf_output)
+        if os.path.exists(outfile):
+            os.remove(outfile)
+        mt.build_makeflow_from_config(obsids, config_file, work_dir=work_dir)
+
+        # make sure the output files we expected appeared
+        nt.assert_true(os.path.exists(outfile))
+        # also make sure the wrapper scripts were made
+        actions = ['ANT_METRICS', 'FIRSTCAL', 'FIRSTCAL_METRICS', 'OMNICAL', 'OMNICAL_METRICS',
+                   'OMNI_APPLY', 'XRFI', 'XRFI_APPLY']
+        pols = self.pols
+        for obsid in obsids:
+            for action in actions:
+                for pol in pols:
+                    wrapper_fn = 'wrapper_' + obsid + '.' + action + '.' + pol + '.sh'
+                    wrapper_fn = os.path.join(work_dir, wrapper_fn)
+                    nt.assert_true(os.path.exists(wrapper_fn))
 
         # clean up after ourselves
         os.remove(outfile)

--- a/hera_opm/tests/test_mf_tools.py
+++ b/hera_opm/tests/test_mf_tools.py
@@ -16,6 +16,8 @@ class TestMethods(object):
                            'zen.2457698.40355.yx.HH.uvcA', 'zen.2457698.40355.yy.HH.uvcA']
         self.obsids_nopol = ['zen.2457698.40355.HH.uvcA']
         self.pols = ['xx', 'xy', 'yx', 'yy']
+        self.obsids_time = ['zen.2457698.30355.xx.HH.uvcA', 'zen.2457698.40355.xx.HH.uvcA',
+                            'zen.2457698.50355.xx.HH.uvcA']
         return
 
     def test_get_config_entry(self):
@@ -52,12 +54,45 @@ class TestMethods(object):
         nt.assert_equal(outfiles, mt.make_outfile_name(obsid, action, pols))
         return
 
+    def test_make_time_neighbor_outfile_name(self):
+        # define args
+        obsid = self.obsids_time[1]
+        action = 'OMNICAL'
+        pol = self.pols[3]
+        outfiles = set(['zen.2457698.30355.yy.HH.uvcA.OMNICAL.yy.out', 'zen.2457698.50355.yy.HH.uvcA.OMNICAL.yy.out'])
+        nt.assert_equal(outfiles, set(mt.make_time_neighbor_outfile_name(obsid, action, self.obsids_time, pol)))
+
+        # test edge cases
+        obsid = self.obsids_time[0]
+        outfiles = set(['zen.2457698.40355.yy.HH.uvcA.OMNICAL.yy.out'])
+        nt.assert_equal(outfiles, set(mt.make_time_neighbor_outfile_name(obsid, action, self.obsids_time, pol)))
+        obsid = self.obsids_time[2]
+        nt.assert_equal(outfiles, set(mt.make_time_neighbor_outfile_name(obsid, action, self.obsids_time, pol)))        
+
+        # run for no polarizations
+        obsid = self.obsids_time[1]
+        outfiles = set(['zen.2457698.30355.xx.HH.uvcA.OMNICAL.out', 'zen.2457698.50355.xx.HH.uvcA.OMNICAL.out'])
+        nt.assert_equal(outfiles, set(mt.make_time_neighbor_outfile_name(obsid, action, self.obsids_time)))
+        return
+
+    def test_make_time_neighbor_outfile_name_errors(self):
+        # test not having the obsid in the supplied list
+        obsid = 'zen.1234567.12345.xx.HH.uvcA'
+        action = 'OMNICAL'
+        nt.assert_raises(ValueError, mt.make_time_neighbor_outfile_name, obsid, action, self.obsids_time)
+
+        # test requesting a pol substitution, but not providing an appropriate obsid
+        fake_obsids = ['zen.1234567.12345.uv', 'zen.1234567.23456.uv', 'zen.1234567.34567.uv']
+        obsid = fake_obsids[1]
+        nt.assert_raises(ValueError, mt.make_time_neighbor_outfile_name, obsid, action, fake_obsids, pol='xx')
+        return
+
     def test_prep_args(self):
         # define args
         obsid = self.obsids_pol[0]
         args = '{basename}'
         pol = self.pols[3]
-        output = 'zen.2457698.40355.yy.uvcA'
+        output = 'zen.2457698.40355.yy.HH.uvcA'
         nt.assert_equal(output, mt.prep_args(args, obsid, pol))
         return
 

--- a/hera_opm/tests/test_mf_tools.py
+++ b/hera_opm/tests/test_mf_tools.py
@@ -104,6 +104,23 @@ class TestMethods(object):
         obsid = self.obsids_pol[0]
         output = 'zen.2457698.40355.xx.HH.uvcA'
         nt.assert_equal(output, mt.prep_args(args, obsid))
+
+        # test having time-adjacent keywords
+        obsid = self.obsids_time[1]
+        obsids = self.obsids_time
+        args = '{basename} {prev_basename} {next_basename}'
+        output = 'zen.2457698.40355.xx.HH.uvcA zen.2457698.30355.xx.HH.uvcA zen.2457698.50355.xx.HH.uvcA'
+        nt.assert_equal(output, mt.prep_args(args, obsid, obsids=obsids))
+
+        # test edge cases
+        obsid = self.obsids_time[0]
+        output = 'zen.2457698.30355.xx.HH.uvcA None zen.2457698.40355.xx.HH.uvcA'
+        nt.assert_equal(output, mt.prep_args(args, obsid, obsids=obsids))
+
+        obsid = self.obsids_time[2]
+        output = 'zen.2457698.50355.xx.HH.uvcA zen.2457698.40355.xx.HH.uvcA None'
+        nt.assert_equal(output, mt.prep_args(args, obsid, obsids=obsids))
+
         return
 
     def test_build_makeflow_from_config(self):


### PR DESCRIPTION
This PR adds support for adding prereqs of neighbors in time (as opposed to polarization). This is necessary for several steps in the pipeline, such as calibration smoothing, that require input from adjacent time steps.