### PR TITLE
Use binary weights

### DIFF
--- a/hera_opm/data/idr2/task_scripts/do_CAL_SMOOTH.sh
+++ b/hera_opm/data/idr2/task_scripts/do_CAL_SMOOTH.sh
@@ -59,6 +59,6 @@ if is_lin_pol $fn; then
         next_data=""
     fi
 
-    echo smooth_cal_run.py ${calfile} ${fn}OCR ${outfile} --filetype miriad --clobber ${prev_cal} ${prev_data} ${next_cal} ${next_data} --time_scale ${time_scale} --mirror_sigmas ${mirror_sigmas} --freq_scale ${freq_scale} --tol ${tol} --window ${window} --skip_wgt ${skip_wgt} --maxiter ${maxiter}
-    smooth_cal_run.py ${calfile} ${fn}OCR ${outfile} --filetype miriad --clobber ${prev_cal} ${prev_data} ${next_cal} ${next_data} --time_scale ${time_scale} --mirror_sigmas ${mirror_sigmas} --freq_scale ${freq_scale} --tol ${tol} --window ${window} --skip_wgt ${skip_wgt} --maxiter ${maxiter}
+    echo smooth_cal_run.py ${calfile} ${fn}OCR ${outfile} --filetype miriad --clobber --binary_wgts ${prev_cal} ${prev_data} ${next_cal} ${next_data} --time_scale ${time_scale} --mirror_sigmas ${mirror_sigmas} --freq_scale ${freq_scale} --tol ${tol} --window ${window} --skip_wgt ${skip_wgt} --maxiter ${maxiter}
+    smooth_cal_run.py ${calfile} ${fn}OCR ${outfile} --filetype miriad --clobber --binary_wgts ${prev_cal} ${prev_data} ${next_cal} ${next_data} --time_scale ${time_scale} --mirror_sigmas ${mirror_sigmas} --freq_scale ${freq_scale} --tol ${tol} --window ${window} --skip_wgt ${skip_wgt} --maxiter ${maxiter}
 fi


### PR DESCRIPTION
I'm seeing strange edge effects in the weighting (see https://github.com/HERA-Team/hera_cal/issues/229 ), even when I normalize the autocorrelations better. It's coming from channels I thought abscal was planning to flag, which is why I probably haven't seen this before.

At any rate, the benefit to my fancy weighting is minimal so let's revert to using binary_weights (i.e. using inverse flags as weights) for now and revisit this question later.