### PR TITLE
Added ABSCAL_APPLY as a prereq for DELAY_XRFI

### DIFF
--- a/hera_opm/data/idr2/idr_v1.cfg
+++ b/hera_opm/data/idr2/idr_v1.cfg
@@ -94,7 +94,7 @@ args = {basename}, ${CAL_XRFI_OPTS:kt_size},
      ${CAL_XRFI_OPTS:time_threshold}
 
 [DELAY_XRFI]
-prereqs = CAL_XRFI
+prereqs = CAL_XRFI, ABSCAL_APPLY
 args = {basename}, ${Options:ex_ants_path}, ${DELAY_XRFI_OPTS:standoff},
      ${DELAY_XRFI_OPTS:horizon}, ${DELAY_XRFI_OPTS:tol}, ${DELAY_XRFI_OPTS:window},
      ${DELAY_XRFI_OPTS:skip_wgt}, ${DELAY_XRFI_OPTS:maxiter}, ${DELAY_XRFI_OPTS:kt_size},


### PR DESCRIPTION
ABSCAL_APPLY should be a prereq for DELAY_XRFI, but it's not necessary for CAL_XRFI (which can run in parallel with ABSCAL_APPLY as the pipeline is currently designed).

I'm not 100% sure of the syntax... @plaplant does this look right?