### PR TITLE
Add timeout option

### DIFF
--- a/hera_opm/data/idr2/idr_v1.cfg
+++ b/hera_opm/data/idr2/idr_v1.cfg
@@ -5,6 +5,7 @@ conda_env = hera
 ex_ants_path = /users/heramgr/hera_software/hera_opm/hera_opm/data/idr2/bad_ants
 base_mem = 10000
 base_cpu = 1
+timeout = 24h
 
 [ABSCAL_OPTS]
 model_files_glob = /lustre/aoc/projects/hera/H1C_IDR2/abscal_models/zen.2458116.*.pp.HH.uvXRS

--- a/hera_opm/data/sample_config/nrao_rtp_options.cfg
+++ b/hera_opm/data/sample_config/nrao_rtp_options.cfg
@@ -1,0 +1,70 @@
+# This is a sample configuration for reanalysis steps at NRAO. Note that
+# specifications exist for steps not in the actions list. Though not necessary,
+# these are not harmful either.
+
+[Options]
+pols = xx,xy,yx,yy
+path_to_do_scripts = ~/hera/hera_op/hera_op/data/sample_task_scripts
+ex_ants = ~/hera/hera_cal/hera_cal/calibrations/herahex_ex_ants.txt
+base_mem = 10000
+base_cpu = 1
+timeout = 1m
+
+[WorkFlow]
+actions = ANT_METRICS, FIRSTCAL, FIRSTCAL_METRICS, OMNICAL, OMNICAL_METRICS,
+          OMNI_APPLY, XRFI, XRFI_APPLY
+
+[ANT_METRICS]
+args = {basename}
+
+[FIRSTCAL]
+args = {basename}, ${Options:ex_ants}
+
+[FIRSTCAL_METRICS]
+args = {basename}
+
+[OMNICAL]
+prereqs = FIRSTCAL_METRICS
+args = {basename}, ${Options:ex_ants}
+
+[OMNICAL_METRICS]
+prereqs = OMNICAL
+args = {basename}
+
+[OMNI_APPLY]
+prereqs = OMNICAL_METRICS
+args = {basename}
+
+[XRFI]
+args = {basename}
+
+[XRFI_APPLY]
+prereqs = XRFI
+args = {basename}
+
+[CLEAN_SUBARRAY]
+prereqs = XRFI_APPLY
+args = {basename}
+
+[CLEAN_ANT_METRICS]
+args = {basename}
+
+[CLEAN_FIRSTCAL]
+prereqs = OMNICAL
+args = {basename}
+
+[CLEAN_FIRSTCAL_METRICS]
+args = {basename}
+
+[CLEAN_OMNICAL]
+prereqs = XRFI_APPLY
+args = {basename}
+
+[CLEAN_OMNICAL_METRICS]
+args = {basename}
+
+[CLEAN_OMNI_APPLY]
+args = {basename}
+
+[CLEAN_XRFI]
+args = {basename}

--- a/scripts/makeflow_nrao.sh
+++ b/scripts/makeflow_nrao.sh
@@ -30,4 +30,4 @@ fi
 
 # actually run makeflow
 # use cluster processing options
-makeflow -T torque -B "-q hera -l walltime=24:00:00 -m a -M heramgr@nrao.edu" $1
+makeflow -T torque -B "-q hera" $1


### PR DESCRIPTION
This PR adds the ability to specify a "timeout" period for jobs in the pipeline. If the job does not complete within this window, the job is terminated, and will not be marked as having successfully finished. This is accomplished using the `timeout` coreutil command, which must be installed on the system. If it is not installed and a timeout value is specified in the config, an error is raised.