### PR TITLE
Fix pycodestyle warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   - conda list
 script:
   - nosetests hera_opm --with-coverage --cover-package=hera_opm
-  - pycodestyle */*.py --ignore=E501
+  - pycodestyle */*.py --ignore=E501,W503
 
 after_success:
   - coveralls

--- a/hera_opm/mf_tools.py
+++ b/hera_opm/mf_tools.py
@@ -369,12 +369,12 @@ def build_makeflow_from_config(obsids, config_file, mf_name=None, work_dir=None)
 
                     # make logfile name
                     # logfile will capture stdout and stderr
-                    logfile = re.sub('\.out', '.log', outfile)
+                    logfile = re.sub(r'\.out', '.log', outfile)
                     logfile = os.path.join(work_dir, logfile)
 
                     # make a small wrapper script that will run the actual command
                     # can't embed if; then statements in makeflow script
-                    wrapper_script = re.sub('\.out', '.sh', outfile)
+                    wrapper_script = re.sub(r'\.out', '.sh', outfile)
                     wrapper_script = "wrapper_{}".format(wrapper_script)
                     wrapper_script = os.path.join(work_dir, wrapper_script)
                     with open(wrapper_script, "w") as f2:

--- a/hera_opm/version.py
+++ b/hera_opm/version.py
@@ -53,10 +53,10 @@ git_branch = version_info['git_branch']
 # String to add to history of any files written with this version of hera_op
 hera_op_version_str = ('hera_op version: ' + version + '.')
 if git_hash is not '':
-    hera_op_version_str += ('  Git origin: ' + git_origin +
-                            '.  Git hash: ' + git_hash +
-                            '.  Git branch: ' + git_branch +
-                            '.  Git description: ' + git_description + '.')
+    hera_op_version_str += ('  Git origin: ' + git_origin
+                            + '.  Git hash: ' + git_hash
+                            + '.  Git branch: ' + git_branch
+                            + '.  Git description: ' + git_description + '.')
 
 
 def main():  # pragma: no cover

--- a/scripts/pipeline_status.py
+++ b/scripts/pipeline_status.py
@@ -12,11 +12,11 @@ from datetime import datetime
 import argparse
 
 # Parse arguments
-parser = argparse.ArgumentParser(description="Check the status of a pipeline. Prints out the total number of jobs of each " +
-                                 "task in the workflow (by the wrapper*.sh files), the number completed (by the .out " +
-                                 "files), the number currently running (which have starting but not stopping times in the" +
-                                 ".log files), and the number errored (which have stopping times in the log but no .out" +
-                                 "file). Also prints the average time elapsed for non-trivial jobs (i.e. those that take" +
+parser = argparse.ArgumentParser(description="Check the status of a pipeline. Prints out the total number of jobs of each "
+                                 "task in the workflow (by the wrapper*.sh files), the number completed (by the .out "
+                                 "files), the number currently running (which have starting but not stopping times in the"
+                                 ".log files), and the number errored (which have stopping times in the log but no .out"
+                                 "file). Also prints the average time elapsed for non-trivial jobs (i.e. those that take"
                                  "more than a second).")
 parser.add_argument("--config_file", type=str, required=True,
                     help="Absolute path to makeflow .cfg file.")
@@ -64,8 +64,8 @@ def elapsed_time(log_lines):
     elif (start is None):
         return -2  # never started
     else:
-        return ((end - start).seconds + 24.0 *
-                60 * 60 * (end - start).days) / 60.0
+        return ((end - start).seconds + 24.0
+                * 60 * 60 * (end - start).days) / 60.0
 
 
 def inspect_log_files(log_files, out_files):


### PR DESCRIPTION
This PR fixes new errors and warnings raised by the pycodestyle check. The biggest change to note is that when writing line breaks with binary operators (`+`, `*`, etc.), the line break should come before the operator (so that the operator is the first character on the continued line). 

@jsdillon this fixes the failures seen on @nkern's PR. We can rebase that branch off of this one when this is merged into master.