### PR TITLE
DO NOT MERGE: Incorporate resource requests into makeflow file

### DIFF
--- a/hera_opm/mf_tools.py
+++ b/hera_opm/mf_tools.py
@@ -293,6 +293,14 @@ def build_makeflow_from_config(obsids, config_file, mf_name=None, work_dir=None)
         print("# makeflow file generated from config file {}".format(cf), file=f)
         print("# created at {}".format(dt), file=f)
 
+        # if present, add resource information
+        base_cpu = get_config_entry(config, 'Options', 'base_cpu', required=False)
+        base_mem = get_config_entry(config, 'Options', 'base_mem', required=False)
+        if base_cpu != []:
+            print("CORES={:d}".format(int(base_cpu[0])), file=f)
+        if base_mem != []:
+            print("MEMORY={:d}".format(int(base_cpu[0])), file=f)
+
         for obsid in obsids:
             # get parent directory
             abspath = os.path.abspath(obsid)


### PR DESCRIPTION
This PR adds resource requirements specified in the `Options` section of the config file into the output makeflow. Testing with the PBS system at NRAO should be done before merging, to ensure these requirements are actually being communicated.