### PR TITLE
Make file handling more robust

### DIFF
--- a/hera_opm/tests/test_mf_tools.py
+++ b/hera_opm/tests/test_mf_tools.py
@@ -22,6 +22,13 @@ class TestMethods(object):
                             'zen.2457698.50355.xx.HH.uvcA']
         return
 
+    def test_get_jd(self):
+        # send in a sample file name
+        filename = "zen.2458000.12345.xx.HH.uv"
+        jd = mt.get_jd(filename)
+        nt.assert_true(jd, "2458000")
+        return
+
     def test_get_config_entry(self):
         # retreive config
         config = ConfigParser(interpolation=ExtendedInterpolation())


### PR DESCRIPTION
This PR allows for more flexibility in the location of data files relative to the working directory of makeflow. The makeflow generation script and actual execution now no longer need be in the same directory as the data. This will allow for more efficiently dealing with multiple days of data. As a part of this, "time neighbors" are restricted to have the same integer JD, which is a general feature of HERA data. This PR addresses Issue #23.