### PR TITLE
Build functionality for blocking on multiple neighbors in time

### DIFF
--- a/hera_opm/data/sample_config/nrao_rtp_time_neighbors.cfg
+++ b/hera_opm/data/sample_config/nrao_rtp_time_neighbors.cfg
@@ -30,6 +30,7 @@ args = {basename}, ${Options:ex_ants}
 [OMNICAL_METRICS]
 prereqs = OMNICAL
 time_prereqs = OMNICAL
+n_time_neighbors = 1
 args = {basename} {prev_basename} {next_basename}
 
 [OMNI_APPLY]

--- a/hera_opm/tests/test_mf_tools.py
+++ b/hera_opm/tests/test_mf_tools.py
@@ -68,19 +68,22 @@ class TestMethods(object):
         obsid = self.obsids_time[1]
         action = 'OMNICAL'
         pol = self.pols[3]
-        outfiles = set(['zen.2457698.30355.xx.HH.uvcA.OMNICAL.yy.out', 'zen.2457698.50355.xx.HH.uvcA.OMNICAL.yy.out'])
-        nt.assert_equal(outfiles, set(mt.make_time_neighbor_outfile_name(obsid, action, self.obsids_time, pol)))
+        outfiles = ['zen.2457698.30355.xx.HH.uvcA.OMNICAL.yy.out',
+                    'zen.2457698.40355.xx.HH.uvcA.OMNICAL.yy.out',
+                    'zen.2457698.50355.xx.HH.uvcA.OMNICAL.yy.out']
+        nt.assert_equal(set(outfiles), set(mt.make_time_neighbor_outfile_name(obsid, action, self.obsids_time, pol)))
 
         # test edge cases
         obsid = self.obsids_time[0]
-        outfiles = set(['zen.2457698.40355.xx.HH.uvcA.OMNICAL.yy.out'])
-        nt.assert_equal(outfiles, set(mt.make_time_neighbor_outfile_name(obsid, action, self.obsids_time, pol)))
+        nt.assert_equal(set(outfiles[:2]), set(mt.make_time_neighbor_outfile_name(obsid, action, self.obsids_time, pol)))
         obsid = self.obsids_time[2]
-        nt.assert_equal(outfiles, set(mt.make_time_neighbor_outfile_name(obsid, action, self.obsids_time, pol)))
+        nt.assert_equal(set(outfiles[1:]), set(mt.make_time_neighbor_outfile_name(obsid, action, self.obsids_time, pol)))
 
         # run for no polarizations
         obsid = self.obsids_time[1]
-        outfiles = set(['zen.2457698.30355.xx.HH.uvcA.OMNICAL.out', 'zen.2457698.50355.xx.HH.uvcA.OMNICAL.out'])
+        outfiles = set(['zen.2457698.30355.xx.HH.uvcA.OMNICAL.out',
+                        'zen.2457698.40355.xx.HH.uvcA.OMNICAL.out',
+                        'zen.2457698.50355.xx.HH.uvcA.OMNICAL.out'])
         nt.assert_equal(outfiles, set(mt.make_time_neighbor_outfile_name(obsid, action, self.obsids_time)))
         return
 


### PR DESCRIPTION
This PR extends the ability of makeflow to wait for neighbors in time to finish a previous analysis step before proceeding. Previously, only immediate neighbors could be waited for (and were hard-coded in). Now, multiple neighbors can be specified, including the entire JD's worth of observations. This is necessary for changes in the approach to calibration smoothing.