### PR TITLE
Add per-task resource options

### DIFF
--- a/hera_opm/tests/test_mf_tools.py
+++ b/hera_opm/tests/test_mf_tools.py
@@ -37,12 +37,12 @@ class TestMethods(object):
         # retrieve specific entry
         header = 'OMNICAL'
         item = 'prereqs'
-        nt.assert_equal(["FIRSTCAL_METRICS"], mt.get_config_entry(config, header, item))
+        nt.assert_equal("FIRSTCAL_METRICS", mt.get_config_entry(config, header, item))
 
         # get nonexistent, but not required, entry
         header = 'OMNICAL'
         item = 'blah'
-        nt.assert_equal([], mt.get_config_entry(config, header, item, required=False))
+        nt.assert_equal(None, mt.get_config_entry(config, header, item, required=False))
 
         # raise an error for a nonexistent, required entry
         nt.assert_raises(AttributeError, mt.get_config_entry, config, header, item)


### PR DESCRIPTION
This PR allows the user to specify per-task processing options in the config file. For instance, if most jobs typically require 8GB of memory, but a few tasks require 16GB, then a special memory limit can be specified for that task only. This can lead to better pipeline throughput, since the scheduler can pack jobs more efficiently if accurate memory requirements are specified.

In addition to this change, a slight cleanup is made to the code. Most notably, `get_config_entry` now returns `None` if the requested option is not present in the config file (instead of an empty list), and for single-valued entries, the entry itself (instead of a length-1 list).