### PR TITLE
Allow user to specify recipient of PBS mail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   # We don't actually use the Travis Python, but this keeps it organized.
   - "2.7"
 install:
+  - git fetch --unshallow --tags
   - sudo apt-get update
   # We do this conditionally because it saves us some downloading if the
   # version is the same.

--- a/hera_opm/data/idr2/idr_v1.cfg
+++ b/hera_opm/data/idr2/idr_v1.cfg
@@ -7,6 +7,7 @@ ex_ants_path = /users/heramgr/hera_software/hera_opm/hera_opm/data/idr2/bad_ants
 base_mem = 8000
 base_cpu = 1
 timeout = 24h
+pbs_mail_user = plaplant@sas.upenn.edu
 
 [OMNI_APPLY_OPTS]
 flag_nchan_low = 50
@@ -95,6 +96,7 @@ args = {basename}
 [OMNICAL]
 prereqs = FIRSTCAL_METRICS
 args = {basename}, ${Options:ex_ants_path}
+mem = 10000
 
 [OMNICAL_METRICS]
 prereqs = OMNICAL

--- a/hera_opm/data/sample_config/nrao_rtp_options.cfg
+++ b/hera_opm/data/sample_config/nrao_rtp_options.cfg
@@ -9,6 +9,7 @@ ex_ants = ~/hera/hera_cal/hera_cal/calibrations/herahex_ex_ants.txt
 base_mem = 10000
 base_cpu = 1
 timeout = 1m
+pbs_mail_user = heramgr@nrao.edu
 
 [WorkFlow]
 actions = ANT_METRICS, FIRSTCAL, FIRSTCAL_METRICS, OMNICAL, OMNICAL_METRICS,

--- a/hera_opm/mf_tools.py
+++ b/hera_opm/mf_tools.py
@@ -290,6 +290,7 @@ def build_makeflow_from_config(obsids, config_file, mf_name=None, work_dir=None)
 
     path_to_do_scripts = get_config_entry(config, 'Options', 'path_to_do_scripts')
     conda_env = get_config_entry(config, 'Options', 'conda_env', required=False)
+    pbs_mail_user = get_config_entry(config, 'Options', 'pbs_mail_user', required=False)
     timeout = get_config_entry(config, 'Options', 'timeout', required=False)
     if timeout is not None:
         # check that the `timeout' command exists on the system
@@ -386,6 +387,8 @@ def build_makeflow_from_config(obsids, config_file, mf_name=None, work_dir=None)
                 batch_options = "-l vmem={0:d}M,mem={0:d}M".format(int(mem))
                 if ncpu is not None:
                     batch_options += ",nodes=1:ppn={:d}".format(int(ncpu))
+                if pbs_mail_user is not None:
+                    batch_options += " -M {}".format(pbs_mail_user)
                 print('export BATCH_OPTIONS = -q hera {}'.format(batch_options), file=f)
 
                 # make rules


### PR DESCRIPTION
This PR allows the user to specify the recipient of PBS mail when running at NRAO. This is necessary to avoid spamming the administrators of the NRAO cluster. There are accordingly some small changes added to the IDR2.1 config file.