### PR TITLE
Make copy of error log when script fails

### DIFF
--- a/hera_opm/mf_tools.py
+++ b/hera_opm/mf_tools.py
@@ -449,6 +449,8 @@ def build_makeflow_from_config(obsids, config_file, mf_name=None, work_dir=None)
                         print("if [ $? -eq 0 ]; then", file=f2)
                         print("  cd {}".format(work_dir), file=f2)
                         print("  touch {}".format(outfile), file=f2)
+                        print("else", file=f2)
+                        print("  mv {0} {1}".format(logfile, logfile + ".error"), file=f2)
                         print("fi", file=f2)
                         print("date", file=f2)
                     # make file executable


### PR DESCRIPTION
This PR makes a copy of the log file when a task fails, so that we diagnose what went wrong. Previously if the job restarted soon after failure, the log would be overwritten.