### PR TITLE
Update hostname for batch job submission

### DIFF
--- a/scripts/makeflow_nrao.sh
+++ b/scripts/makeflow_nrao.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Copyright (c) 2018 The HERA Collaboration
+# This code is licensed under the BSD 2-clause license
 
 # This command is makeflow_nrao.sh
 # Use this to run makeflow on the NRAO cluster environment
@@ -23,8 +24,8 @@ if ! [ "$(makeflow_analyze -k $1)" ]; then
 fi
 
 # make sure that we're on the right host
-if [ "$(hostname)" != "nmpost-master" ]; then
-    echo "Error: batch submission jobs can only be run from nmpost-master; please log in there and retry"
+if [ "$(hostname)" != "herapost-master" ]; then
+    echo "Error: batch submission jobs can only be run from herapost-master; please log in there and retry"
     exit 4
 fi
 

--- a/scripts/makeflow_nrao.sh
+++ b/scripts/makeflow_nrao.sh
@@ -5,6 +5,10 @@
 # This command is makeflow_nrao.sh
 # Use this to run makeflow on the NRAO cluster environment
 # Several options are set for the execution on the cluster
+#
+# Args:
+#   1) name of makeflow file
+#   2) number of simultaneous jobs to submit (optional)
 
 # test that makeflow is on the PATH
 if ! [ -x "$(command -v makeflow)"  ]; then
@@ -18,7 +22,7 @@ if [ "$#" -lt 1 ]; then
     exit 2
 fi
 
-if ! [ "$(makeflow_analyze -k $1)" ]; then
+if ! [ "$(makeflow_analyze -k "${1}")" ]; then
     echo "Error: makeflow file is not parsable by makeflow; please contact hera_opm maintainer"
     exit 3
 fi
@@ -30,5 +34,9 @@ if [ "$(hostname)" != "herapost-master" ]; then
 fi
 
 # actually run makeflow
-# use cluster processing options
-makeflow -T torque $1
+# test to see if we have a second argument (number of jobs to submit simultaneously)
+if [ "$#" -gt 1 ]; then
+    makeflow -T torque -J "${2}" "${1}"
+else
+    makeflow -T torque "${1}"
+fi


### PR DESCRIPTION
At NRAO, batch job submission (and makeflow processing) should be done from the new `herapost-master` node. The `makeflow_nrao.sh` script has been updated to reflect this change.