### PR TITLE
Lstbin fixed lst start

### DIFF
--- a/hera_opm/data/idr2/idr2_lstbin.cfg
+++ b/hera_opm/data/idr2/idr2_lstbin.cfg
@@ -16,6 +16,7 @@ rephase = False
 ntimes_per_file = 60
 dlst = None
 lst_start = 0.0
+fixed_lst_start = True
 vis_units = Jy
 parallelize = True
 file_ext = grp1.of2.{}.{}.{:7.5f}.uvXRAA
@@ -29,5 +30,5 @@ data_files = \'data/zen.2458043.*.{pol}.HH.uvXRAA\',
 actions = LSTBIN
 
 [LSTBIN]
-args = sig_clip, sigma, min_N, rephase, ntimes_per_file, lst_start, dlst, vis_units, output_file_select, file_ext, outdir
+args = sig_clip, sigma, min_N, rephase, ntimes_per_file, lst_start, fixed_lst_start, dlst, vis_units, output_file_select, file_ext, outdir
 

--- a/hera_opm/data/idr2/task_scripts/do_LSTBIN.sh
+++ b/hera_opm/data/idr2/task_scripts/do_LSTBIN.sh
@@ -13,12 +13,13 @@ source ${src_dir}/_common.sh
 # 4 - rephase flag
 # 5 - ntimes_per_file
 # 6 - lst_start
-# 7 - dlst
-# 8 - vis_units
-# 9 - output_file_select
-# 10 - file_ext
-# 11 - outdir
-# 12+ - series of glob-parsable search strings (in quotations!) to files to LSTBIN
+# 7 - fixed_lst_start
+# 8 - dlst
+# 9 - vis_units
+# 10 - output_file_select
+# 11 - file_ext
+# 12 - outdir
+# 13+ - series of glob-parsable search strings (in quotations!) to files to LSTBIN
 
 # get positional arguments
 sig_clip=${1}
@@ -27,13 +28,14 @@ min_N=${3}
 rephase=${4}
 ntimes_per_file=${5}
 lst_start=${6}
-dlst=${7}
-vis_units=${8}
-output_file_select=${9}
-file_ext=${10}
-outdir=${11}
+fixed_lst_start=${7}
+dlst=${8}
+vis_units=${9}
+output_file_select=${10}
+file_ext=${11}
+outdir=${12}
 data_files=($@)
-data_files=(${data_files[*]:11})
+data_files=(${data_files[*]:12})
 
 # set special kwargs
 if [ $sig_clip == True ]; then
@@ -46,6 +48,11 @@ if [ $rephase == True ]; then
 else
     rephase=""
 fi
+if [ $fixed_lst_start == True ]; then
+    fixed_lst_start="--fixed_lst_start"
+else
+    fixed_lst_start=""
+fi
 
-echo lstbin_run.py --dlst ${dlst} --file_ext ${file_ext} --outdir ${outdir} --ntimes_per_file ${ntimes_per_file} ${sig_clip} --sigma ${sigma} --min_N ${min_N} --lst_start ${lst_start} --vis_units ${vis_units} --output_file_select ${output_file_select} --overwrite ${data_files[@]}
-lstbin_run.py --dlst ${dlst} --file_ext ${file_ext} --outdir ${outdir} --ntimes_per_file ${ntimes_per_file} ${sig_clip} --sigma ${sigma} --min_N ${min_N} --lst_start ${lst_start} --vis_units ${vis_units} --output_file_select ${output_file_select} --overwrite ${data_files[@]}
+echo lstbin_run.py --dlst ${dlst} --file_ext ${file_ext} --outdir ${outdir} --ntimes_per_file ${ntimes_per_file} ${rephase} ${sig_clip} --sigma ${sigma} --min_N ${min_N} --lst_start ${lst_start} ${fixed_lst_start} --vis_units ${vis_units} --output_file_select ${output_file_select} --overwrite ${data_files[@]}
+lstbin_run.py --dlst ${dlst} --file_ext ${file_ext} --outdir ${outdir} --ntimes_per_file ${ntimes_per_file} ${rephase} ${sig_clip} --sigma ${sigma} --min_N ${min_N} --lst_start ${lst_start} ${fixed_lst_start} --vis_units ${vis_units} --output_file_select ${output_file_select} --overwrite ${data_files[@]}

--- a/hera_opm/data/sample_config/lstbin.cfg
+++ b/hera_opm/data/sample_config/lstbin.cfg
@@ -14,6 +14,7 @@ rephase = False
 ntimes_per_file = 60
 dlst = None
 lst_start = 0.0
+fixed_lst_start = False
 vis_units = Jy
 parallelize = True
 file_ext = grp1.of2.{}.{}.{:7.5f}.uvXRAA
@@ -24,4 +25,4 @@ data_files = \'zen.2458043.*.{pol}.HH.uvXRAA\',
              \'zen.2458045.*.{pol}.HH.uvXRAA\'
 
 [LSTBIN]
-args = sig_clip, sigma, min_N, rephase, ntimes_per_file, lst_start, dlst, vis_units, output_file_select, file_ext, outdir
+args = sig_clip, sigma, min_N, rephase, ntimes_per_file, lst_start, fixed_lst_start, dlst, vis_units, output_file_select, file_ext, outdir

--- a/hera_opm/data/sample_config/lstbin_options.cfg
+++ b/hera_opm/data/sample_config/lstbin_options.cfg
@@ -15,6 +15,7 @@ rephase = False
 ntimes_per_file = 60
 dlst = None
 lst_start = 0.0
+fixed_lst_start = False
 vis_units = Jy
 parallelize = True
 file_ext = grp1.of2.{}.{}.{:7.5f}.uvXRAA
@@ -25,4 +26,4 @@ data_files = \'zen.2458043.*.{pol}.HH.uvXRAA\',
              \'zen.2458045.*.{pol}.HH.uvXRAA\'
 
 [LSTBIN]
-args = sig_clip, sigma, min_N, rephase, ntimes_per_file, lst_start, dlst, vis_units, output_file_select, file_ext, outdir
+args = sig_clip, sigma, min_N, rephase, ntimes_per_file, lst_start, fixed_lst_start, dlst, vis_units, output_file_select, file_ext, outdir

--- a/hera_opm/mf_tools.py
+++ b/hera_opm/mf_tools.py
@@ -643,6 +643,7 @@ def build_lstbin_makeflow_from_config(config_file, mf_name=None, **kwargs):
                 else:
                     dlst = float(dlst)
                 lst_start = float(get_config_entry(config, 'LSTBIN_OPTS', 'lst_start', required=True))
+                fixed_lst_start = bool(get_config_entry(config, "LSTBIN_OPTS", "fixed_lst_start"), required=True)
                 ntimes_per_file = int(get_config_entry(config, 'LSTBIN_OPTS', 'ntimes_per_file', required=True))
 
                 # pre-process files to determine the number of output files
@@ -650,7 +651,7 @@ def build_lstbin_makeflow_from_config(config_file, mf_name=None, **kwargs):
                 _datafiles = map(lambda df: str(df), _datafiles)
                 _datafiles = map(lambda df: sorted(glob.glob(df)), _datafiles)
 
-                output = lstbin.config_lst_bin_files(_datafiles, dlst=dlst, lst_start=lst_start,
+                output = lstbin.config_lst_bin_files(_datafiles, dlst=dlst, lst_start=lst_start, fixed_lst_start=fixed_lst_start,
                                                      ntimes_per_file=ntimes_per_file)
                 nfiles = len(output[3])
             else:

--- a/hera_opm/mf_tools.py
+++ b/hera_opm/mf_tools.py
@@ -643,7 +643,7 @@ def build_lstbin_makeflow_from_config(config_file, mf_name=None, **kwargs):
                 else:
                     dlst = float(dlst)
                 lst_start = float(get_config_entry(config, 'LSTBIN_OPTS', 'lst_start', required=True))
-                fixed_lst_start = bool(get_config_entry(config, "LSTBIN_OPTS", "fixed_lst_start"), required=True)
+                fixed_lst_start = bool(get_config_entry(config, "LSTBIN_OPTS", "fixed_lst_start", required=True))
                 ntimes_per_file = int(get_config_entry(config, 'LSTBIN_OPTS', 'ntimes_per_file', required=True))
 
                 # pre-process files to determine the number of output files


### PR DESCRIPTION
adds an argument `fixed_lst_start` to the LSTBIN pipeline. this is an optional flag to start the LST grid at a specified value, rather than defaulting to the first LST in the data