### PR TITLE
Add `toml` to package requirements and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ export PATH=${PATH}:${HOME}/cctools/bin
 For convenience, it is helpful to add the `export` statement to your `.bashrc`
 file, so that the `makeflow` are always on your `PATH`.
 
+`hera_opm` stores workflow configuration files in the [TOML
+format](https://github.com/toml-lang/toml). The [toml
+package](https://github.com/uiri/toml) is required. To install it, either:
+```
+conda install toml
+```
+or
+```
+pip install toml
+```
+
 To install the `hera_opm` package, simply:
 ```
 python setup.py install

--- a/hera_opm/mf_tools.py
+++ b/hera_opm/mf_tools.py
@@ -485,6 +485,8 @@ def build_analysis_makeflow_from_config(obsids, config_file, mf_name=None, work_
                 args = get_config_entry(config, action, "args", required=False)
                 if not isinstance(args, list):
                     args = [args]
+                # convert args list to strings
+                args = [str(a) for a in args]
                 args = ' '.join(args)
 
                 # make outfile name

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup_args = {
     'scripts': glob('scripts/*.py') + glob('scripts/*.sh'),
     'version': version.version,
     'package_data': {'hera_opm': data_files},
+    'install_requires': ['toml>=0.9.4'],
     'zip_safe': False,
 }
 


### PR DESCRIPTION
As part of the upgrade to python3 compatibility, the configuration files were transitioned to follow the TOML specification. This PR adds the python `toml` package to the list of requirements, and updates the README.