### PR TITLE
Make repo installable in python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ install:
 script:
   - nosetests hera_opm --with-coverage --cover-package=hera_opm
   - pycodestyle --ignore=E501,W503
+  - python setup.py install
 after_success:
   - coveralls
 notifications:

--- a/setup.py
+++ b/setup.py
@@ -40,4 +40,4 @@ setup_args = {
 }
 
 if __name__ == '__main__':
-    apply(setup, (), setup_args)
+    setup(**setup_args)


### PR DESCRIPTION
Through a funny oversight, the code of the repo was being tested running in python3 (and found compatible), but actually _installing_ the repo was not done as part of the tests. Had that been the case, we would have discovered that the `setup.py` file was using the deprecated `apply` function, which was removed in python3. This oversight has been remedied, and now the repo is explicitly installed as part of the Travis script to test for this.

In the future, we may migrate to using [pytest](https://github.com/pytest-dev/pytest/) instead of nosetests, so that we could run tests with `python setup.py test` instead of the current method.