### PR TITLE
Use pytest instead of nosetests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   # create environment and install dependencies
   - conda create -q -n testenv python="$PYTHON_VERSION"
   - source activate testenv
-  - conda install nose pip scipy matplotlib six toml astropy ephem pycodestyle coveralls h5py
+  - conda install pytest pytest-runner pip scipy matplotlib six toml astropy ephem pycodestyle coveralls h5py
   - conda install -c conda-forge aipy
   - pip install git+https://github.com/HERA-Team/pyuvdata.git
   - pip install git+https://github.com/HERA-Team/linsolve.git
@@ -38,9 +38,8 @@ install:
   - pip install git+https://github.com/HERA-Team/hera_cal.git
   - conda list
 script:
-  - nosetests hera_opm --with-coverage --cover-package=hera_opm
+  - coverage run --source=hera_opm setup.py test
   - pycodestyle --ignore=E501,W503
-  - python setup.py install
 after_success:
   - coveralls
 notifications:

--- a/hera_opm/tests/test_utils.py
+++ b/hera_opm/tests/test_utils.py
@@ -1,5 +1,5 @@
 """Tests for utils.py"""
-import nose.tools as nt
+import pytest
 import os
 from hera_opm.data import DATA_PATH
 import hera_opm.utils as utils
@@ -15,17 +15,18 @@ def test_get_makeflow_ArgumentParser():
     parsed_args = a.parse_args(args)
 
     # make sure we got what we expected
-    nt.assert_equal(parsed_args.config, config_file)
-    nt.assert_equal(parsed_args.output, output_file)
+    assert parsed_args.config == config_file
+    assert parsed_args.output == output_file
     for obsid in obsids:
-        nt.assert_true(obsid in parsed_args.files)
+        assert obsid in parsed_args.files
 
     return
 
 
 def test_get_cleaner_ArgumentParser():
     # raise error for requesting unknown function
-    nt.assert_raises(AssertionError, utils.get_cleaner_ArgumentParser, 'blah')
+    with pytest.raises(AssertionError):
+        utils.get_cleaner_ArgumentParser('blah')
 
     # test getting each type of argparser
     # wrapper
@@ -33,22 +34,22 @@ def test_get_cleaner_ArgumentParser():
     work_dir = '/foo/bar'
     args = [work_dir]
     parsed_args = a.parse_args(args)
-    nt.assert_equal(work_dir, parsed_args.directory)
+    assert parsed_args.directory == work_dir
 
     # output
     a = utils.get_cleaner_ArgumentParser('output')
     parsed_args = a.parse_args(args)
-    nt.assert_equal(work_dir, parsed_args.directory)
+    assert parsed_args.directory == work_dir
 
     # logs
     a = utils.get_cleaner_ArgumentParser('logs')
     output_file = "mf.log"
     args = [work_dir, '-o', output_file]
     parsed_args = a.parse_args(args)
-    nt.assert_equal(work_dir, parsed_args.directory)
-    nt.assert_equal(output_file, parsed_args.output)
-    nt.assert_false(parsed_args.overwrite)
-    nt.assert_true(parsed_args.remove_original)
-    nt.assert_false(parsed_args.zip)
+    assert parsed_args.directory == work_dir
+    assert parsed_args.output == output_file
+    assert not parsed_args.overwrite
+    assert parsed_args.remove_original
+    assert not parsed_args.zip
 
     return

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [metadata]
 description-file = README.md
+
+[aliases]
+test = pytest

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,8 @@ setup_args = {
     'package_data': {'hera_opm': data_files},
     'install_requires': ['toml>=0.9.4'],
     'zip_safe': False,
+    'setup_requires': ['pytest-runner', 'toml>=0.9.4'],
+    'tests_require': ['pytest', 'toml>=0.9.4'],
 }
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR transitions away from nose as a testing framework, and instead uses pytest. Instead of invoking `nosetests hera_opm` in the top level directory, users should instead run `python setup.py test`. This approach requires `pytest` and `pytest-runner` instead of `nose`, but is a better long-term strategy due to the deprecation of nose.

Fixes #52.