### PR TITLE
Make fixes for IDR2.2

### DIFF
--- a/hera_opm/data/sample_config/lstbin.toml
+++ b/hera_opm/data/sample_config/lstbin.toml
@@ -2,6 +2,7 @@
 makeflow_type = "lstbin"
 pols = "xx"
 path_to_do_scripts = "~/hera/hera_opm/hera_opm/data/sample_task_scripts"
+source_script = "~/.bashrc"
 conda_env = "hera"
 base_mem = 10000
 base_cpu = 1

--- a/hera_opm/data/sample_config/nrao_rtp.toml
+++ b/hera_opm/data/sample_config/nrao_rtp.toml
@@ -6,6 +6,7 @@
 makeflow_type = "analysis"
 pols = ["xx", "xy", "yx", "yy"]
 path_to_do_scripts = "~/hera/hera_op/hera_op/data/sample_task_scripts"
+source_script = "~/.bashrc"
 conda_env = "hera"
 ex_ants = "~/hera/hera_cal/hera_cal/calibrations/herahex_ex_ants.txt"
 base_mem = 10000

--- a/hera_opm/mf_tools.py
+++ b/hera_opm/mf_tools.py
@@ -602,7 +602,7 @@ def build_analysis_makeflow_from_config(
                     with open(wrapper_script, "w") as f2:
                         print("#!/bin/bash", file=f2)
                         if conda_env is not None:
-                            print("source activate {}".format(conda_env), file=f2)
+                            print("conda activate {}".format(conda_env), file=f2)
                         print("date", file=f2)
                         print("cd {}".format(parent_dir), file=f2)
                         if timeout is not None:

--- a/hera_opm/mf_tools.py
+++ b/hera_opm/mf_tools.py
@@ -443,6 +443,7 @@ def build_analysis_makeflow_from_config(
 
     path_to_do_scripts = get_config_entry(config, "Options", "path_to_do_scripts")
     conda_env = get_config_entry(config, "Options", "conda_env", required=False)
+    source_script = get_config_entry(config, "Options", "source_script", required=False)
     pbs_mail_user = get_config_entry(config, "Options", "pbs_mail_user", required=False)
     timeout = get_config_entry(config, "Options", "timeout", required=False)
     if timeout is not None:
@@ -601,6 +602,8 @@ def build_analysis_makeflow_from_config(
                     wrapper_script = os.path.join(work_dir, wrapper_script)
                     with open(wrapper_script, "w") as f2:
                         print("#!/bin/bash", file=f2)
+                        if source_script is not None:
+                            print("source {}".format(source_script), file=f2)
                         if conda_env is not None:
                             print("conda activate {}".format(conda_env), file=f2)
                         print("date", file=f2)
@@ -682,6 +685,7 @@ def build_lstbin_makeflow_from_config(
         pol_list = [pol_list]
     path_to_do_scripts = get_config_entry(config, "Options", "path_to_do_scripts")
     conda_env = get_config_entry(config, "Options", "conda_env", required=False)
+    source_script = get_config_entry(config, "Options", "source_scriopt", required=False)
     timeout = get_config_entry(config, "Options", "timeout", required=False)
     if timeout is not None:
         # check that the `timeout' command exists on the system
@@ -821,8 +825,10 @@ def build_lstbin_makeflow_from_config(
                 wrapper_script = os.path.join(work_dir, wrapper_script)
                 with open(wrapper_script, "w") as f2:
                     print("#!/bin/bash", file=f2)
+                    if source_script is not None:
+                        print("source {}".format(source_script, file=f2))
                     if conda_env is not None:
-                        print("source activate {}".format(conda_env), file=f2)
+                        print("conda activate {}".format(conda_env), file=f2)
                     print("date", file=f2)
                     print("cd {}".format(parent_dir), file=f2)
                     if timeout is not None:

--- a/pipelines/h1c/idr2/v2/idr2_2.toml
+++ b/pipelines/h1c/idr2/v2/idr2_2.toml
@@ -1,12 +1,12 @@
 [Options]
 makeflow_type = "analysis"
-path_to_do_scripts = "/users/jsdillon/Libraries/hera_opm/pipelines/h1c/idr2/v2/task_scripts"
-conda_env = "hera"
-ex_ants_path = "/users/jsdillon/Libraries/hera_opm/pipelines/h1c/idr2/v2/bad_ants"
+path_to_do_scripts = "/users/heramgr/hera_software/hera_opm/pipelines/h1c/idr2/v2/task_scripts"
+conda_env = "hera3"
+ex_ants_path = "/users/heramgr/hera_software/hera_opm/pipelines/h1c/idr2/v2/bad_ants"
 base_mem = 8000
 base_cpu = 1
 timeout = "24h"
-pbs_mail_user = "jsdillon+makeflow@berkeley.edu"
+pbs_mail_user = "plaplant@sas.upenn.edu"
 
 [REDCAL_OPTS]
 ant_z_thresh = 4.0
@@ -149,5 +149,5 @@ args = ["{basename}", "${REFLECTIONS_OPTS:dly_ranges}", "${REFLECTIONS_OPTS:wind
 prereqs = "CAL_SMOOTH"
 time_prereqs = "CAL_SMOOTH"
 n_time_neighbors = "all"
-mem = 32000
+mem = 24000
 args = ["{basename}", "${IMAGING_OPTS:casa}", "${IMAGING_OPTS:casa_imaging_scripts}", "${IMAGING_OPTS:calibration}"]

--- a/pipelines/h1c/idr2/v2/idr2_2.toml
+++ b/pipelines/h1c/idr2/v2/idr2_2.toml
@@ -1,6 +1,7 @@
 [Options]
 makeflow_type = "analysis"
 path_to_do_scripts = "/users/heramgr/hera_software/hera_opm/pipelines/h1c/idr2/v2/task_scripts"
+source_script = "~/.bashrc"
 conda_env = "hera3"
 ex_ants_path = "/users/heramgr/hera_software/hera_opm/pipelines/h1c/idr2/v2/bad_ants"
 base_mem = 8000

--- a/pipelines/h1c/idr2/v2/task_scripts/do_IMAGING.sh
+++ b/pipelines/h1c/idr2/v2/task_scripts/do_IMAGING.sh
@@ -48,12 +48,17 @@ cd ${image_outdir}
 echo ${casa} -c ${casa_imaging_scripts}/opm_imaging.py --uvfitsname ${cwd}/${uvfits_file} --image ${uvfits_file_out}
 ${casa} -c ${casa_imaging_scripts}/opm_imaging.py --uvfitsname ${cwd}/${uvfits_file} --image ${uvfits_file_out}
 
-# erase uvfits and MS file
+# erase uvfits file
 cd ${cwd}
 echo rm ${uvfits_file}
 rm ${uvfits_file}
-echo rm ${ms_file}
-rm -r ${ms_file} || echo "No ${ms_file} to remove."
+
+# keep ms files for 2458098
+JD=`get_jd "${1}" | cut -c 1-7`
+if [ $JD -ne 2458098 ]; then
+    echo rm ${ms_file}
+    rm -r ${ms_file} || echo "No ${ms_file} to remove."
+fi
 
 # remove calibrated visibility
 if [ ! -z "${calibration}" ]; then

--- a/scripts/launch_screen_sessions.sh
+++ b/scripts/launch_screen_sessions.sh
@@ -2,31 +2,33 @@
 # Copyright 2019 The HERA Collaboration
 # This code is licensed under the BSD 2-clause License
 
-# This script is launch_screen_sessions.sh
+# This script is launch_screen_sessions.sh.
 # Use this script to create screen sessions, automatically create
 # a makeflow from a TOML file, and run the makeflow.
 #
 # Args:
-#   1) full path to the .toml file
+#   1) path to the .toml file
 #   2) path to folder with data files
 #   3) ending of data files. Files will be enumerated
 #      by using a glob `*.ending'
 #   4) number of simultaneous batch jobs to run, optional
 #
 # Example usage:
-#   launch_screen_sessions.sh /lustre/aoc/projects/hera/H1C_IDR2/IDR2_2 .HH.uvh5 20
+#   launch_screen_sessions.sh idr2_2.toml /lustre/aoc/projects/hera/H1C_IDR2/IDR2_2 .HH.uvh5 20
 #
 # In the sample above, the folder IDR2_2 contains a series of folders
 # indexed by JD (e.g., 2458098, 2458099, etc.). These folders contain
 # the raw data files used by hera_opm to generate a workflow, with the
 # extension given by the third argument (.HH.uvh5). The optional fourth
-# argument gives the number of simiultaneous jobs to run **for each day
+# argument gives the number of simiultaneous jobs to submit **for each day
 # in the workflow**.
 
 # get full path of toml file, in case it's not absolute
 toml_path=`realpath "${1}"`
 
 # get current environment, to activate inside of screen
+# should be an environment with hera_opm installed, because
+# `makeflow_nrao.sh' is called inside
 conda_env=`conda info --envs | grep '*' | cut -d ' ' -f1`
 
 # make list of JDs to process
@@ -53,7 +55,7 @@ for JD in ${JD_LIST}; do
     	cmd="conda activate $conda_env; makeflow_nrao.sh ${mf_file}\n"
     fi
 
-    # launch screen session and send commands
+    # launch screen session named by JD and send commands
     screen -d -m -S "${JD}"
     screen -S "${JD}" -p 0 -X stuff "${cmd}"
 

--- a/scripts/launch_screen_sessions.sh
+++ b/scripts/launch_screen_sessions.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Copyright 2019 The HERA Collaboration
+# This code is licensed under the BSD 2-clause License
+
+# This script is launch_screen_sessions.sh
+# Use this script to create screen sessions, automatically create
+# a makeflow from a TOML file, and run the makeflow.
+#
+# Args:
+#   1) full path to the .toml file
+#   2) path to folder with data files
+#   3) ending of data files. Files will be enumerated
+#      by using a glob `*.ending'
+#   4) number of simultaneous batch jobs to run, optional
+#
+# Example usage:
+#   launch_screen_sessions.sh /lustre/aoc/projects/hera/H1C_IDR2/IDR2_2 .HH.uvh5 20
+#
+# In the sample above, the folder IDR2_2 contains a series of folders
+# indexed by JD (e.g., 2458098, 2458099, etc.). These folders contain
+# the raw data files used by hera_opm to generate a workflow, with the
+# extension given by the third argument (.HH.uvh5). The optional fourth
+# argument gives the number of simiultaneous jobs to run **for each day
+# in the workflow**.
+
+# get full path of toml file, in case it's not absolute
+toml_path=`realpath "${1}"`
+
+# get current environment, to activate inside of screen
+conda_env=`conda info --envs | grep '*' | cut -d ' ' -f1`
+
+# make list of JDs to process
+# defaults to all JD-like folders contained in argument $2
+JD_LIST=`ls "${2}" | egrep "[0-9]{7}" | tr '\n' ' '`
+
+# loop over days
+for JD in ${JD_LIST}; do
+    # make encapsulating folder
+    mkdir -p "${JD}"
+
+    # build makeflow
+    cd "${JD}"
+    file_list=`ls "${2}"/"${JD}"/*"${3}" | tr '\n' ' '`
+    build_makeflow_from_config.py -c "${toml_path}" ${file_list}
+
+    # get full path to .mf file
+    mf_file=`realpath *.mf`
+
+    # build command to be fed to screen session
+    if [ "$#" -gt 3 ]; then
+    	cmd="conda activate $conda_env; makeflow_nrao.sh ${mf_file} ${4}\n"
+    else
+    	cmd="conda activate $conda_env; makeflow_nrao.sh ${mf_file}\n"
+    fi
+
+    # launch screen session and send commands
+    screen -d -m -S "${JD}"
+    screen -S "${JD}" -p 0 -X stuff "${cmd}"
+
+    # go back up a level
+    cd ..
+done


### PR DESCRIPTION
This PR adds some small tweaks to the actual workflow, as well as a script for automatically generating makeflows and screen sessions to run them. Also, due to recent changes in how conda environment activation is handled inside of shell scripts (see discussion [here](https://github.com/conda/conda/issues/7126)), the `source_script` option is supported, to be used in conjunction with the `conda_env` option.