### PR TITLE
Make tests run if package is not installed

### DIFF
--- a/hera_opm/tests/test_mf_tools.py
+++ b/hera_opm/tests/test_mf_tools.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import gzip
 import glob
-from hera_opm.data import DATA_PATH
+from ..data import DATA_PATH
 from hera_opm import mf_tools as mt
 import six
 import toml


### PR DESCRIPTION
This PR allows the user to run `pytest` in the root directory without having to explicitly install the package. This should make testing a little more flexible.