### PR TITLE
lstbin pol handling for updated reduction pipe pol handling

### DIFF
--- a/hera_opm/data/sample_config/lstbin_v2.toml
+++ b/hera_opm/data/sample_config/lstbin_v2.toml
@@ -1,0 +1,31 @@
+# IDR2 v2 examle config
+[Options]
+makeflow_type = "lstbin"
+path_to_do_scripts = "~/hera/hera_opm/hera_opm/data/sample_task_scripts"
+source_script = "~/.bashrc"
+conda_env = "hera"
+base_mem = 10000
+base_cpu = 1
+
+[LSTBIN_OPTS]
+sig_clip = true
+sigma = 5
+min_N = 5
+rephase = false
+ntimes_per_file = 60
+dlst = "None"
+lst_start = 0.0
+fixed_lst_start = false
+vis_units = "Jy"
+parallelize = true
+file_ext = "grp1.of2.{type}.{time:7.5f}.uvcA"
+filetype = "miriad"
+outdir = "../data"
+parent_dir = "../data"
+data_files = ["zen.2457698.40355.HH.uvcA",
+              "zen.2457698.40355.HH.uvcA"]
+
+[LSTBIN]
+args = ["sig_clip", "sigma", "min_N", "rephase", "ntimes_per_file", "lst_start",
+        "fixed_lst_start", "dlst", "vis_units", "output_file_select", "file_ext",
+        "filetype", "outdir"]

--- a/hera_opm/mf_tools.py
+++ b/hera_opm/mf_tools.py
@@ -680,7 +680,7 @@ def build_lstbin_makeflow_from_config(
     config["LSTBIN_OPTS"]["output_file_select"] = str("None")
 
     # get general options
-    pol_list = get_config_entry(config, "Options", "pols", required=True)
+    pol_list = get_config_entry(config, "Options", "pols", required=False)
     if not isinstance(pol_list, list):
         pol_list = [pol_list]
     path_to_do_scripts = get_config_entry(config, "Options", "path_to_do_scripts")
@@ -705,6 +705,11 @@ def build_lstbin_makeflow_from_config(
     else:
         base, ext = os.path.splitext(cf)
         fn = "{0}.mf".format(base)
+
+    # get filetypes
+    filetype = get_config_entry(config, "LSTBIN_OPTS", "filetype", required=False)
+    if filetype is None:
+        filetype = 'uvh5'
 
     # determine whether or not to parallelize
     parallelize = get_config_entry(config, "LSTBIN_OPTS", "parallelize", required=True)
@@ -744,7 +749,8 @@ def build_lstbin_makeflow_from_config(
             datafiles = get_config_entry(
                 config, "LSTBIN_OPTS", "data_files", required=True
             )
-            datafiles = [df.format(pol=pol) for df in datafiles]
+            if pol is not None:
+                datafiles = [df.format(pol=pol) for df in datafiles]
             datafiles = [os.path.join(parent_dir, df) for df in datafiles]
 
             # get number of output files for this pol
@@ -782,6 +788,7 @@ def build_lstbin_makeflow_from_config(
                     lst_start=lst_start,
                     fixed_lst_start=fixed_lst_start,
                     ntimes_per_file=ntimes_per_file,
+                    filetype=filetype,
                 )
                 nfiles = len(output[3])
             else:
@@ -794,8 +801,12 @@ def build_lstbin_makeflow_from_config(
                     config["LSTBIN_OPTS"]["output_file_select"] = str(output_file_index)
 
                 # make outfile list
-                outfile = "lstbin_outfile_{}.{}.{}.out".format(
-                    output_file_index, "LSTBIN", pol
+                if pol is not None:
+                    polstr = ".{}".format(pol)
+                else:
+                    polstr = ""
+                outfile = "lstbin_outfile_{}.{}{}.out".format(
+                    output_file_index, "LSTBIN", polstr
                 )
 
                 # get args list for lst-binning step

--- a/hera_opm/tests/test_mf_tools.py
+++ b/hera_opm/tests/test_mf_tools.py
@@ -520,6 +520,7 @@ def test_build_lstbin_makeflow_from_config(config_options):
     mt.clean_wrapper_scripts(work_dir)
 
     # test v2 LSTBIN pipe with no pols provided
+    mf_output = os.path.splitext(os.path.basename(config_file))[0] + ".mf"
     outfile = os.path.join(work_dir, mf_output)
     if os.path.exists(outfile):
         os.remove(outfile)

--- a/hera_opm/tests/test_mf_tools.py
+++ b/hera_opm/tests/test_mf_tools.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import gzip
 import glob
-from ..data import DATA_PATH
+from hera_opm.data import DATA_PATH
 from hera_opm import mf_tools as mt
 import six
 import toml
@@ -513,6 +513,20 @@ def test_build_lstbin_makeflow_from_config(config_options):
         config_file, mf_name=outfile, work_dir=work_dir, parent_dir=DATA_PATH
     )
 
+    assert os.path.exists(outfile)
+
+    # clean up after ourselves
+    os.remove(outfile)
+    mt.clean_wrapper_scripts(work_dir)
+
+    # test v2 LSTBIN pipe with no pols provided
+    if os.path.exists(outfile):
+        os.remove(outfile)
+    mt.build_lstbin_makeflow_from_config(config_file.replace("lstbin", "lstbin_v2"), mf_name="lstbin.mf",
+        work_dir=work_dir, parent_dir=DATA_PATH
+    )
+
+    # make sure the output files we expected appeared
     assert os.path.exists(outfile)
 
     # clean up after ourselves

--- a/hera_opm/tests/test_mf_tools.py
+++ b/hera_opm/tests/test_mf_tools.py
@@ -520,11 +520,11 @@ def test_build_lstbin_makeflow_from_config(config_options):
     mt.clean_wrapper_scripts(work_dir)
 
     # test v2 LSTBIN pipe with no pols provided
+    outfile = os.path.join(work_dir, mf_output)
     if os.path.exists(outfile):
         os.remove(outfile)
     mt.build_lstbin_makeflow_from_config(config_file.replace("lstbin", "lstbin_v2"), mf_name="lstbin.mf",
-        work_dir=work_dir, parent_dir=DATA_PATH
-    )
+                                         work_dir=work_dir, parent_dir=DATA_PATH)
 
     # make sure the output files we expected appeared
     assert os.path.exists(outfile)

--- a/pipelines/h1c/idr2/v2/task_scripts/do_LSTBIN.sh
+++ b/pipelines/h1c/idr2/v2/task_scripts/do_LSTBIN.sh
@@ -18,9 +18,10 @@ source ${src_dir}/_common.sh
 # 9 - vis_units
 # 10 - output_file_select
 # 11 - file_ext
-# 12 - outdir
-# 13 - calibration
-# 14+ - series of glob-parsable search strings (in quotations!) to files to LSTBIN
+# 12 - filetype
+# 13 - outdir
+# 14 - calibration
+# 15+ - series of glob-parsable search strings (in quotations!) to files to LSTBIN
 
 # get positional arguments
 sig_clip=${1}
@@ -34,10 +35,11 @@ dlst=${8}
 vis_units=${9}
 output_file_select=${10}
 file_ext=${11}
-outdir=${12}
-calibration=${13}
+filetype=${12}
+outdir=${13}
+calibration=${14}
 data_files=($@)
-data_files=(${data_files[*]:13})
+data_files=(${data_files[*]:14})
 
 # if calibration suffix is not empty, parse it and apply it
 if [ ! -z "${calibration}" ]; then
@@ -65,5 +67,5 @@ else
     fixed_lst_start=""
 fi
 
-echo lstbin_run.py --dlst ${dlst} --file_ext ${file_ext} --outdir ${outdir} --ntimes_per_file ${ntimes_per_file} ${rephase} ${sig_clip} --sigma ${sigma} --min_N ${min_N} --lst_start ${lst_start} ${fixed_lst_start} --vis_units ${vis_units} --output_file_select ${output_file_select} --input_cals ${input_cals[@]} --overwrite ${data_files[@]}
-lstbin_run.py --dlst ${dlst} --file_ext ${file_ext} --outdir ${outdir} --ntimes_per_file ${ntimes_per_file} ${rephase} ${sig_clip} --sigma ${sigma} --min_N ${min_N} --lst_start ${lst_start} ${fixed_lst_start} --vis_units ${vis_units} --output_file_select ${output_file_select} --input_cals ${input_cals[@]} --overwrite ${data_files[@]}
+echo lstbin_run.py --dlst ${dlst} --file_ext ${file_ext} --outdir ${outdir} --ntimes_per_file ${ntimes_per_file} ${rephase} ${sig_clip} --sigma ${sigma} --min_N ${min_N} --lst_start ${lst_start} ${fixed_lst_start} --vis_units ${vis_units} --output_file_select ${output_file_select} --filetype ${filetype} --input_cals ${input_cals[@]} --overwrite ${data_files[@]}
+lstbin_run.py --dlst ${dlst} --file_ext ${file_ext} --outdir ${outdir} --ntimes_per_file ${ntimes_per_file} ${rephase} ${sig_clip} --sigma ${sigma} --min_N ${min_N} --lst_start ${lst_start} ${fixed_lst_start} --vis_units ${vis_units} --output_file_select ${output_file_select} --filetype ${filetype} --input_cals ${input_cals[@]} --overwrite ${data_files[@]}


### PR DESCRIPTION
Allows `lstbin` type pipelines to forego specifying polarizations, as all files are 4pol files now