### PR TITLE
Fix lstbin source script option

### DIFF
--- a/hera_opm/mf_tools.py
+++ b/hera_opm/mf_tools.py
@@ -747,7 +747,12 @@ def build_lstbin_makeflow_from_config(
             if pol is not None:
                 datafiles = [df.format(pol=pol) for df in datafiles]
             # encapsulate in double quotes
-            datafiles = ["'{}'".format('"{}"'.format(os.path.join(parent_dir, df.strip('"').strip("'")))) for df in datafiles]
+            datafiles = [
+                "'{}'".format(
+                    '"{}"'.format(os.path.join(parent_dir, df.strip('"').strip("'")))
+                )
+                for df in datafiles
+            ]
 
             # get number of output files for this pol
             if parallelize:
@@ -772,7 +777,9 @@ def build_lstbin_makeflow_from_config(
                 )
 
                 # pre-process files to determine the number of output files
-                _datafiles = [sorted(glob.glob(df.strip("'").strip('"'))) for df in datafiles]
+                _datafiles = [
+                    sorted(glob.glob(df.strip("'").strip('"'))) for df in datafiles
+                ]
                 if six.PY2:
                     _datafiles = [
                         [df.encode("utf-8") for df in li] for li in _datafiles

--- a/hera_opm/mf_tools.py
+++ b/hera_opm/mf_tools.py
@@ -685,7 +685,7 @@ def build_lstbin_makeflow_from_config(
         pol_list = [pol_list]
     path_to_do_scripts = get_config_entry(config, "Options", "path_to_do_scripts")
     conda_env = get_config_entry(config, "Options", "conda_env", required=False)
-    source_script = get_config_entry(config, "Options", "source_scriopt", required=False)
+    source_script = get_config_entry(config, "Options", "source_script", required=False)
     timeout = get_config_entry(config, "Options", "timeout", required=False)
     if timeout is not None:
         # check that the `timeout' command exists on the system
@@ -832,7 +832,7 @@ def build_lstbin_makeflow_from_config(
                 with open(wrapper_script, "w") as f2:
                     print("#!/bin/bash", file=f2)
                     if source_script is not None:
-                        print("source {}".format(source_script, file=f2))
+                        print("source {}".format(source_script), file=f2)
                     if conda_env is not None:
                         print("conda activate {}".format(conda_env), file=f2)
                     print("date", file=f2)

--- a/hera_opm/tests/test_mf_tools.py
+++ b/hera_opm/tests/test_mf_tools.py
@@ -4,8 +4,8 @@ import os
 import shutil
 import gzip
 import glob
-from hera_opm.data import DATA_PATH
-from hera_opm import mf_tools as mt
+from ..data import DATA_PATH
+from .. import mf_tools as mt
 import six
 import toml
 
@@ -289,6 +289,14 @@ def test_build_analysis_makeflow_from_config(config_options):
                 wrapper_fn = os.path.join(work_dir, wrapper_fn)
                 assert os.path.exists(wrapper_fn)
 
+                # check that the wrapper scripts have the right lines in them
+                with open(wrapper_fn) as infile:
+                    lines = infile.readlines()
+                assert lines[0].strip() == "#!/bin/bash"
+                assert lines[1].strip() == "source ~/.bashrc"
+                assert lines[2].strip() == "conda activate hera"
+                assert lines[3].strip() == "date"
+
     # clean up after ourselves
     os.remove(outfile)
     mt.clean_wrapper_scripts(work_dir)
@@ -515,6 +523,17 @@ def test_build_lstbin_makeflow_from_config(config_options):
 
     assert os.path.exists(outfile)
 
+    # check that the wrapper scripts have the right lines in them
+    wrapper_scripts = [
+        f for f in sorted(os.listdir(work_dir)) if f.startswith("wrapper_")
+    ]
+    with open(os.path.join(work_dir, wrapper_scripts[0])) as infile:
+        lines = infile.readlines()
+    assert lines[0].strip() == "#!/bin/bash"
+    assert lines[1].strip() == "source ~/.bashrc"
+    assert lines[2].strip() == "conda activate hera"
+    assert lines[3].strip() == "date"
+
     # clean up after ourselves
     os.remove(outfile)
     mt.clean_wrapper_scripts(work_dir)
@@ -524,8 +543,12 @@ def test_build_lstbin_makeflow_from_config(config_options):
     outfile = os.path.join(work_dir, mf_output)
     if os.path.exists(outfile):
         os.remove(outfile)
-    mt.build_lstbin_makeflow_from_config(config_file.replace("lstbin", "lstbin_v2"), mf_name="lstbin.mf",
-                                         work_dir=work_dir, parent_dir=DATA_PATH)
+    mt.build_lstbin_makeflow_from_config(
+        config_file.replace("lstbin", "lstbin_v2"),
+        mf_name="lstbin.mf",
+        work_dir=work_dir,
+        parent_dir=DATA_PATH,
+    )
 
     # make sure the output files we expected appeared
     assert os.path.exists(outfile)

--- a/scripts/pipeline_status.py
+++ b/scripts/pipeline_status.py
@@ -115,7 +115,7 @@ def inspect_log_files(log_files, out_files):
         # It timed out
         if (
             timeout is not None
-            and (np.abs(runtimes[-1]) > .99 * timeout)
+            and (np.abs(runtimes[-1]) > 0.99 * timeout)
             and (log_file.replace(".log", ".out") not in out_files)
             and (log_file.replace(".log.error", ".out") not in out_files)
         ):
@@ -140,22 +140,29 @@ def inspect_log_files(log_files, out_files):
         print("\n")
 
     runtimes = np.array(runtimes)
-    finished_runtimes = runtimes[runtimes > 10. / 60.0]
+    finished_runtimes = runtimes[runtimes > 10.0 / 60.0]
     if len(finished_runtimes) > 0:
         average_runtime = np.mean(finished_runtimes)
     else:
         average_runtime = np.nan
 
-    return average_runtime, np.sum(runtimes == -1), len(errored_logs), len(timed_out_logs)
+    return (
+        average_runtime,
+        np.sum(runtimes == -1),
+        len(errored_logs),
+        len(timed_out_logs),
+    )
 
 
 def filter_errors(log_files):
-    '''If there are both error and log files, pick the newer one.'''
+    """If there are both error and log files, pick the newer one."""
     newest_log_files = []
-    unique_bases = np.unique([f.replace('.log.error', '.log') for f in log_files])
+    unique_bases = np.unique([f.replace(".log.error", ".log") for f in log_files])
     for log_file in unique_bases:
-        err_file = log_file.replace('.log', '.log.error')
-        if err_file in log_files and log_file in log_files:  # both an error file and a log file
+        err_file = log_file.replace(".log", ".log.error")
+        if (
+            err_file in log_files and log_file in log_files
+        ):  # both an error file and a log file
             with open(err_file, "r") as f:
                 err_lines = f.readlines()
                 err_start = dateparser.parse(err_lines[0], ignoretz=True)


### PR DESCRIPTION
There was an error in the way that the `source_script` option was being handled in the lstbin pipeline. This PR fixes that, as well as slightly reformatting some files.