### PR TITLE
Add redcal to revamp_rtp

### DIFF
--- a/pipelines/h3c/rtp/v1/rtp.toml
+++ b/pipelines/h3c/rtp/v1/rtp.toml
@@ -20,6 +20,16 @@ streak_sig = 20.0
 other_sig = 5.0
 N_samp_thresh = 10
 
+[REDCAL_OPTS]
+ant_z_thresh = 4.0
+solar_horizon = 0.0
+nInt_to_load = 8
+flag_nchan_low = 0
+flag_nchan_high = 0
+min_bl_cut = 15
+max_bl_cut = 100
+iter0_prefix = ".iter0"
+
 [WorkFlow]
 actions = ["SETUP", "UPLOAD","MAKE_SESSION", "ANT_METRICS",
            "ADD_LIBRARIAN_ANT_METRICS", "ADD_MC_ANT_METRICS", "SSINS",
@@ -53,3 +63,13 @@ args = ["{basename}", "${SSINS_OPTS:streak_sig}", "${SSINS_OPTS:other_sig}",
 
 [ADD_LIBRARIAN_SSINS]
 args = ["{basename}"]
+
+[REDCAL]
+args = ["{basename}", "${REDCAL_OPTS:ant_z_thresh}",
+        "${REDCAL_OPTS:solar_horizon}", "${REDCAL_OPTS:flag_nchan_low}",
+        "${REDCAL_OPTS:flag_nchan_high}", "${REDCAL_OPTS:nInt_to_load}",
+        "${REDCAL_OPTS:min_bl_cut}", "${REDCAL_OPTS:max_bl_cut}",
+        "${REDCAL_OPTS:iter0_prefix}", "${ANT_METRICS_OPTS:extension}"]
+
+[ADD_LIBRARIAN_REDCAL]
+args = ["{basename}", "${REDCAL_OPTS:iter0_prefix}"]

--- a/pipelines/h3c/rtp/v1/task_scripts/do_ADD_LIBRARIAN_REDCAL.sh
+++ b/pipelines/h3c/rtp/v1/task_scripts/do_ADD_LIBRARIAN_REDCAL.sh
@@ -1,0 +1,61 @@
+#! /bin/bash
+set -e
+
+# import common functions
+src_dir="$(dirname "$0")"
+source ${src_dir}/_common.sh
+
+# Parameters are set in the configuration file. Here we define their positions,
+# which must be consistent wtih the config.
+# 1 - (raw) filename
+# 2 - iter0_prefix: if not "", save omnical results after the 0th interation with this prefix iff there will be a rerun
+fn=${1}
+iter0_prefix=${2}
+
+# get the integer portion of the JD
+jd=$(get_int_jd ${1})
+
+
+# We only want to upload ant metrics on sum files
+# check if the string does not contain the word diff
+if ! stringContain diff "${fn}"; then
+
+  # Upload firstcal results
+  firstcal_f = `echo ${fn%.uvh5}.first.calfits`
+  echo librarian upload local-rtp ${firstcal_f} ${jd}/${firstcal_f}
+  librarian upload local-rtp ${firstcal_f} ${jd}/${firstcal_f}  
+
+  # Upload omnical results
+  omnical_f = `echo ${fn%.uvh5}.omni.calfits`
+  echo librarian upload local-rtp ${omnical_f} ${jd}/${omnical_f}
+  librarian upload local-rtp ${omnical_f} ${jd}/${omnical_f}
+
+  # Upload omnical visibility solutions
+  omnivis_f = `echo ${fn%.uvh5}.omni_vis.uvh5`
+  echo librarian upload local-rtp ${omnivis_f} ${jd}/${omnivis_f}
+  librarian upload local-rtp ${omnivis_f} ${jd}/${omnivis_f}
+
+  # check if iter0 is not empty
+  if [ ! -z "$iter0_prefix" ]; then
+    iter0_firstcal_f=`echo ${fn%.uvh5}${iter0_prefix}.first.calfits`
+    # check if iter0_firstcal_f exists (not guaranteed if no re-run is triggered)
+    if [ -f "$iter0_firstcal_f" ]; then
+        echo librarian upload local-rtp ${iter0_firstcal_f} ${jd}/${iter0_firstcal_f}
+        librarian upload local-rtp ${iter0_firstcal_f} ${jd}/${iter0_firstcal_f}
+    fi
+
+    iter0_omnical_f=`echo ${fn%.uvh5}${iter0_prefix}.omni.calfits`
+    # check if iter0_omnical_f exists (not guaranteed if no re-run is triggered)
+    if [ -f "$iter0_omnical_f" ]; then
+        echo librarian upload local-rtp ${iter0_omnical_f} ${jd}/${iter0_omnical_f}
+        librarian upload local-rtp ${iter0_omnical_f} ${jd}/${iter0_omnical_f}
+    fi
+
+    iter0_omnivis_f=`echo ${fn%.uvh5}${iter0_prefix}.omni_vis.uvh5`
+    # check if iter0_omnivis_f exists (not guaranteed if no re-run is triggered)
+    if [ -f "$iter0_omnivis_f" ]; then
+        echo librarian upload local-rtp ${iter0_omnivis_f} ${jd}/${iter0_omnivis_f}
+        librarian upload local-rtp ${iter0_omnivis_f} ${jd}/${iter0_omnivis_f}
+    fi
+  fi
+fi

--- a/pipelines/h3c/rtp/v1/task_scripts/do_REDCAL.sh
+++ b/pipelines/h3c/rtp/v1/task_scripts/do_REDCAL.sh
@@ -1,0 +1,43 @@
+#! /bin/bash
+set -e
+
+# import common functions
+src_dir="$(dirname "$0")"
+source ${src_dir}/_common.sh
+
+# Parameters are set in the configuration file, here we define their positions,
+# which must be consistent with the config.
+# 1 - filename
+# 2 - ant_z_thresh: Threshold of modified z-score for chi^2 per antenna above which antennas are thrown away and calibration is re-run iteratively.
+# 3 - solar_horizon: When the Sun is above this altitude in degrees, calibration is skipped and the integrations are flagged.
+# 4 - flag_nchan_low: integer number of channels at the low frequency end of the band to always flag (default 0)
+# 5 - flag_nchan_high: integer number of channels at the high frequency end of the band to always flag (default 0)
+# 6 - nInt_to_load: number of integrations to load and calibrate simultaneously. Lower numbers save memory, but incur a CPU overhead.
+# 7 - min_bl_cut: cut redundant groups with average baseline lengths shorter than this length in meters
+# 8 - max_bl_cut: cut redundant groups with average baseline lengths longer than this length in meters
+# 9 - iter0_prefix: if not "", save omnical results after the 0th interation with this prefix iff there will be a rerun
+# 10 - ant_metrics_extension: file extension to replace .uvh5 with to get ant_metrics files
+fn="${1}"
+ant_z_thresh="${2}"
+solar_horizon="${3}"
+flag_nchan_low="${4}"
+flag_nchan_high="${5}"
+nInt_to_load="${6}"
+min_bl_cut="${7}"
+max_bl_cut="${8}"
+iter0_prefix="${9}"
+ant_metrics_extension="${10}"
+
+# get exants
+# TODO: get exants from M&C
+exants=""
+
+# get metrics_json filename, removing extension and appending ant_metrics_extension
+metrics_f=`echo ${fn%.uvh5}${ant_metrics_extension}`
+
+echo redcal_run.py ${fn} --ex_ants ${exants} --ant_metrics_file ${metrics_f}  --ant_z_thresh ${ant_z_thresh} --solar_horizon ${solar_horizon} \
+    --flag_nchan_low ${flag_nchan_low} --flag_nchan_high ${flag_nchan_high} --nInt_to_load ${nInt_to_load} --min_bl_cut ${min_bl_cut} \
+    --max_bl_cut ${max_bl_cut} --iter0_prefix ${iter0_prefix} --clobber --verbose
+redcal_run.py ${fn} --ex_ants ${exants} --ant_metrics_file ${metrics_f}  --ant_z_thresh ${ant_z_thresh} --solar_horizon ${solar_horizon} \
+    --flag_nchan_low ${flag_nchan_low} --flag_nchan_high ${flag_nchan_high} --nInt_to_load ${nInt_to_load} --min_bl_cut ${min_bl_cut} \
+    --max_bl_cut ${max_bl_cut} --iter0_prefix ${iter0_prefix} --clobber --verbose


### PR DESCRIPTION
This PR adds redundant calibration.

The big TODO here is to inherit the "known bad" and "needs checking"  antennas from M&C as exants.

It relies on the current master branch of hera_cal, so that should be updated on site before this gets merged in.