### PR TITLE
Fix commit messages

### DIFF
--- a/pipelines/h3c/rtp/v1/task_scripts/do_MAKE_NOTEBOOK.sh
+++ b/pipelines/h3c/rtp/v1/task_scripts/do_MAKE_NOTEBOOK.sh
@@ -24,7 +24,7 @@ then
 
     git pull origin master
     git add ${OUTPUT}
-    git commit -m 'RTP data inspection notebook commit for JD ${jd}'
+    git commit -m "RTP data inspection notebook commit for JD ${jd}"
     git push origin master
 
     cd ${src_dir}

--- a/pipelines/h3c/rtp/v1/task_scripts/do_MAKE_REDCAL_NOTEBOOK.sh
+++ b/pipelines/h3c/rtp/v1/task_scripts/do_MAKE_REDCAL_NOTEBOOK.sh
@@ -24,7 +24,7 @@ then
 
     git pull origin master
     git add ${OUTPUT}
-    git commit -m 'RTP redcal notebook commit for JD ${jd}'
+    git commit -m "RTP redcal notebook commit for JD ${jd}"
     git push origin master
 
     cd ${src_dir}


### PR DESCRIPTION
Turns out variables in single quotes aren't evaluated, but variables in double quotes are. 

Thanks Stack Overflow: https://stackoverflow.com/questions/46342375/add-env-var-to-commit-message