### PR TITLE
Update RTP launch script

### DIFF
--- a/scripts/make_rtp_workflow.py
+++ b/scripts/make_rtp_workflow.py
@@ -14,6 +14,7 @@ import numpy as np
 from psycopg2.errors import UniqueViolation
 from sqlalchemy.exc import IntegrityError
 
+from pyuvdata import UVData
 import hera_mc.mc as mc
 from hera_opm import mf_tools as mt
 
@@ -54,6 +55,15 @@ while True:
         file_paths = [
             os.path.join(STORAGE_LOCATION, new_file) for new_file in new_files
         ]
+
+        # make sure we can read the metadata properly
+        for filename in file_paths:
+            try:
+                uvd = UVData()
+                uvd.read(filename, read_data=False)
+            except (KeyError, OSError, ValueError):
+                # ignore the file
+                file_paths.remove(filename)
 
         # make M&C RTP process events for each file
         parser = mc.get_mc_argument_parser()

--- a/scripts/make_rtp_workflow.py
+++ b/scripts/make_rtp_workflow.py
@@ -110,7 +110,9 @@ while True:
         mt.build_makeflow_from_config(file_paths, WORKFLOW_CONFIG, mf_path, MF_LOCATION)
 
         # launch workflow inside of screen
-        cmd = "conda activate {}; makeflow -T slurm {}\n".format(CONDA_ENV, mf_path)
+        cmd = "conda deactivate; conda activate {}; makeflow -T slurm {}\n".format(
+            CONDA_ENV, mf_path
+        )
         screen_name = "rtp_{}".format(str(int(jd0)))
         screen_cmd1 = ["screen", "-d", "-m", "-S", screen_name]
         screen_cmd2 = ["screen", "-S", screen_name, "-p", "0", "-X", "stuff", cmd]


### PR DESCRIPTION
This PR updates the script that launches the RTP workflow. There are now checks to ensure that the files produced are valid (according to the metadata), and a slightly updated screen command that is run. This seems to be working okay on site.