### PR TITLE
Allow filenames without proper JD string of form `zen.???????.?????.*`

### DIFF
--- a/hera_opm/mf_tools.py
+++ b/hera_opm/mf_tools.py
@@ -21,16 +21,25 @@ def get_jd(filename):
     ----------
     filename : str
         File name. Assumed to follow standard convention where name is
-        `zen.xxxxxxx.xxxxx.uv`.
+        `zen.xxxxxxx.xxxxx.uv`. If it does not, a warning is issued and
+        None is returned.
 
     Returns
     -------
     str
-        The integer JD (fractional part truncated).
+        The integer JD (fractional part truncated). Returns None if
+        filename does not match assumed format.
 
     """
-    m = re.match(r"zen\.([0-9]{7})\.[0-9]{5}\.", filename)
-    return m.groups()[0]
+    try:
+        m = re.match(r"zen\.([0-9]{7})\.[0-9]{5}\.", filename)
+        return m.groups()[0]
+    except AttributeError:
+        warnings.warn(
+            "Warning: Unable to figure out the JD associated with "
+            f"{filename}. This may affect chunking and prerequisites."
+        )        
+        return None
 
 
 def _interpolate_config(config, entry):

--- a/hera_opm/mf_tools.py
+++ b/hera_opm/mf_tools.py
@@ -38,7 +38,7 @@ def get_jd(filename):
         warnings.warn(
             "Warning: Unable to figure out the JD associated with "
             f"{filename}. This may affect chunking and prerequisites."
-        )        
+        )
         return None
 
 

--- a/hera_opm/mf_tools.py
+++ b/hera_opm/mf_tools.py
@@ -26,7 +26,7 @@ def get_jd(filename):
 
     Returns
     -------
-    str
+    str or None
         The integer JD (fractional part truncated). Returns None if
         filename does not match assumed format.
 

--- a/hera_opm/mf_tools.py
+++ b/hera_opm/mf_tools.py
@@ -35,10 +35,9 @@ def get_jd(filename):
         m = re.match(r"zen\.([0-9]{7})\.[0-9]{5}\.", filename)
         return m.groups()[0]
     except AttributeError:
-        warnings.warn(
-            "Warning: Unable to figure out the JD associated with "
-            f"{filename}. This may affect chunking and prerequisites."
-        )
+        wmsg = f"Unable to figure out the JD associated with {filename}. "
+        wmsg += "This may affect chunking and prerequisites."
+        warnings.warn(wmsg)
         return None
 
 

--- a/hera_opm/tests/test_mf_tools.py
+++ b/hera_opm/tests/test_mf_tools.py
@@ -121,6 +121,19 @@ def test_get_jd():
     return
 
 
+def test_get_jd_no_match():
+    """Test if the file does not contain the JD in a way we recognize"""
+    filename = "foo.txt"
+    with pytest.warns(UserWarning) as record:
+        retval = mt.get_jd(filename)
+    assert len(record) == 1
+    message = record[0].message.args[0]
+    assert message.startswith("Unable to figure out the JD associated with foo.txt")
+    assert retval is None
+
+    return
+
+
 def test_get_config_entry(config_options):
     """Test getting a specific entry from a config file."""
     # retreive config


### PR DESCRIPTION
This PR allows one to use filenames without the proper JD string format, but it warns the user that this could screw up chunking and prerequisite handling.

I believe this closes #121 