### PR TITLE
Add slurm monitoring

### DIFF
--- a/hera_opm/data/sample_config/nrao_rtp_chunk_size.toml
+++ b/hera_opm/data/sample_config/nrao_rtp_chunk_size.toml
@@ -9,6 +9,7 @@ conda_env = "hera"
 ex_ants = "~/hera/hera_cal/hera_cal/calibrations/herahex_ex_ants.txt"
 base_mem = 10000
 base_cpu = 1
+mandc_report = true
 
 [WorkFlow]
 actions = ["ANT_METRICS", "FIRSTCAL", "FIRSTCAL_METRICS", "OMNICAL",
@@ -36,7 +37,7 @@ args = ["{basename}", "{prev_basename}", "{next_basename}"]
 prereqs = "OMNICAL_METRICS"
 chunk_size = 3
 stride_length = 2
-args = "{basename}"
+args = ["{basename} {obsid_list}"]
 
 [XRFI]
 args = "{basename}"

--- a/hera_opm/mf_tools.py
+++ b/hera_opm/mf_tools.py
@@ -1113,16 +1113,17 @@ def build_analysis_makeflow_from_config(
                                 file=f2,
                             )
                             if len(obsid_list) > 1:
-                                print(
-                                    f"add_rtp_task_jobid.py --multiple {filename} {action} $SLURM_JOB_ID"
-                                )
                                 obsid_list_str = " ".join(obsid_list)
                                 print(
-                                    f"add_rtp_task_multiple_track.py {filename} {action} {obsid_list_str}"
+                                    f"add_rtp_task_jobid.py {filename} {action} "
+                                    f"$SLURM_JOB_ID --obsid_list {obsid_list_str}",
+                                    file=f2,
                                 )
                             else:
                                 print(
-                                    f"add_rtp_task_jobid.py {filename} {action} $SLURM_JOB_ID"
+                                    f"add_rtp_task_jobid.py {filename} {action} "
+                                    "$SLURM_JOB_ID",
+                                    file=f2,
                                 )
                         if timeout is not None:
                             print(

--- a/hera_opm/mf_tools.py
+++ b/hera_opm/mf_tools.py
@@ -1087,6 +1087,9 @@ def build_analysis_makeflow_from_config(
                     collect_stragglers=collect_stragglers,
                     return_obsid_list=True,
                 )
+                # cast obsid list to string for later
+                if len(obsid_list) > 1:
+                    obsid_list_str = " ".join(obsid_list)
 
                 for outfile in outfiles:
                     # make logfile name
@@ -1109,7 +1112,6 @@ def build_analysis_makeflow_from_config(
                         print("cd {}".format(parent_dir), file=f2)
                         if mandc_report:
                             if len(obsid_list) > 1:
-                                obsid_list_str = " ".join(obsid_list)
                                 print(
                                     f"add_rtp_process_event.py {filename} {action} "
                                     f"started --file_list {obsid_list_str}",

--- a/hera_opm/mf_tools.py
+++ b/hera_opm/mf_tools.py
@@ -1112,12 +1112,12 @@ def build_analysis_makeflow_from_config(
                                 obsid_list_str = " ".join(obsid_list)
                                 print(
                                     f"add_rtp_process_event.py {filename} {action} "
-                                    f"started --obsid_list {obsid_list_str}",
+                                    f"started --file_list {obsid_list_str}",
                                     file=f2,
                                 )
                                 print(
                                     f"add_rtp_task_jobid.py {filename} {action} "
-                                    f"$SLURM_JOB_ID --obsid_list {obsid_list_str}",
+                                    f"$SLURM_JOB_ID --file_list {obsid_list_str}",
                                     file=f2,
                                 )
                             else:
@@ -1145,7 +1145,7 @@ def build_analysis_makeflow_from_config(
                             if len(obsid_list) > 1:
                                 print(
                                     f"  add_rtp_process_event.py {filename} {action} "
-                                    f"finished --obsid_list {obsid_list_str}",
+                                    f"finished --file_list {obsid_list_str}",
                                     file=f2,
                                 )
                             else:
@@ -1161,7 +1161,7 @@ def build_analysis_makeflow_from_config(
                             if len(obsid_list) > 1:
                                 print(
                                     f"  add_rtp_process_event.py {filename} {action} "
-                                    f"error --obsid_list {obsid_list_str}",
+                                    f"error --file_list {obsid_list_str}",
                                     file=f2,
                                 )
                             else:

--- a/hera_opm/mf_tools.py
+++ b/hera_opm/mf_tools.py
@@ -803,7 +803,7 @@ def build_analysis_makeflow_from_config(
         # check that the `timeout' command exists on the system
         try:
             subprocess.check_output(["timeout", "--help"])
-        except OSError:
+        except OSError:  # pragma: no cover
             warnings.warn(
                 'A value for the "timeout" option was specified,'
                 " but the `timeout' command does not appear to be"
@@ -1108,20 +1108,24 @@ def build_analysis_makeflow_from_config(
                         print("date", file=f2)
                         print("cd {}".format(parent_dir), file=f2)
                         if mandc_report:
-                            print(
-                                "add_rtp_process_event.py {0} {1} started".format(
-                                    filename, action
-                                ),
-                                file=f2,
-                            )
                             if len(obsid_list) > 1:
                                 obsid_list_str = " ".join(obsid_list)
+                                print(
+                                    f"add_rtp_process_event.py {filename} {action} "
+                                    f"started --obsid_list {obsid_list_str}",
+                                    file=f2,
+                                )
                                 print(
                                     f"add_rtp_task_jobid.py {filename} {action} "
                                     f"$SLURM_JOB_ID --obsid_list {obsid_list_str}",
                                     file=f2,
                                 )
                             else:
+                                print(
+                                    f"add_rtp_process_event.py {filename} {action} "
+                                    "started",
+                                    file=f2,
+                                )
                                 print(
                                     f"add_rtp_task_jobid.py {filename} {action} "
                                     "$SLURM_JOB_ID",
@@ -1138,22 +1142,34 @@ def build_analysis_makeflow_from_config(
                             print("{0} {1}".format(command, prepped_args), file=f2)
                         print("if [ $? -eq 0 ]; then", file=f2)
                         if mandc_report:
-                            print(
-                                "  add_rtp_process_event.py {0} {1} finished".format(
-                                    filename, action
-                                ),
-                                file=f2,
-                            )
+                            if len(obsid_list) > 1:
+                                print(
+                                    f"  add_rtp_process_event.py {filename} {action} "
+                                    f"finished --obsid_list {obsid_list_str}",
+                                    file=f2,
+                                )
+                            else:
+                                print(
+                                    f"  add_rtp_process_event.py {filename} {action} "
+                                    "finished",
+                                    file=f2,
+                                )
                         print("  cd {}".format(work_dir), file=f2)
                         print("  touch {}".format(outfile), file=f2)
                         print("else", file=f2)
                         if mandc_report:
-                            print(
-                                "  add_rtp_process_event.py {0} {1} error".format(
-                                    filename, action
-                                ),
-                                file=f2,
-                            )
+                            if len(obsid_list) > 1:
+                                print(
+                                    f"  add_rtp_process_event.py {filename} {action} "
+                                    f"error --obsid_list {obsid_list_str}",
+                                    file=f2,
+                                )
+                            else:
+                                print(
+                                    f"  add_rtp_process_event.py {filename} {action} "
+                                    "error",
+                                    file=f2,
+                                )
                         print(
                             "  mv {0} {1}".format(logfile, logfile + ".error"), file=f2
                         )
@@ -1362,7 +1378,7 @@ def build_lstbin_makeflow_from_config(
         # check that the `timeout' command exists on the system
         try:
             subprocess.check_output(["timeout", "--help"])
-        except OSError:
+        except OSError:  # pragma: no cover
             warnings.warn(
                 'A value for the "timeout" option was specified,'
                 " but the `timeout' command does not appear to be"

--- a/hera_opm/mf_tools.py
+++ b/hera_opm/mf_tools.py
@@ -1109,7 +1109,9 @@ def build_analysis_makeflow_from_config(
                         print("cd {}".format(parent_dir), file=f2)
                         if mandc_report:
                             print(
-                                "add_rtp_process_event.py {} started".format(filename),
+                                "add_rtp_process_event.py {0} {1} started".format(
+                                    filename, action
+                                ),
                                 file=f2,
                             )
                             if len(obsid_list) > 1:
@@ -1137,8 +1139,8 @@ def build_analysis_makeflow_from_config(
                         print("if [ $? -eq 0 ]; then", file=f2)
                         if mandc_report:
                             print(
-                                "  add_rtp_process_event.py {} finished".format(
-                                    filename
+                                "  add_rtp_process_event.py {0} {1} finished".format(
+                                    filename, action
                                 ),
                                 file=f2,
                             )
@@ -1147,7 +1149,9 @@ def build_analysis_makeflow_from_config(
                         print("else", file=f2)
                         if mandc_report:
                             print(
-                                "  add_rtp_process_event.py {} error".format(filename),
+                                "  add_rtp_process_event.py {0} {1} error".format(
+                                    filename, action
+                                ),
                                 file=f2,
                             )
                         print(

--- a/hera_opm/tests/test_mf_tools.py
+++ b/hera_opm/tests/test_mf_tools.py
@@ -1285,6 +1285,28 @@ def test_prep_args_obsid_list_with_stragglers(config_options):
     return
 
 
+def test_prep_args_obsid_list_returned(config_options):
+    # define args to parse
+    obsids_list = config_options["obsids"]
+    args = "{obsid_list}"
+    obsid = obsids_list[1]
+
+    args, obsid_list = mt.prep_args(
+        args,
+        obsid,
+        obsids=obsids_list,
+        chunk_size="3",
+        time_centered=None,
+        collect_stragglers=False,
+        return_obsid_list=True,
+    )
+    prepped_args = " ".join(obsids_list[0:3])
+    assert args == prepped_args
+    assert obsid_list == list(obsids_list)
+
+    return
+
+
 def test_prep_args_obsid_list_error(config_options):
     # define args to parse
     obsids_list = config_options["obsids"]

--- a/scripts/make_rtp_workflow.py
+++ b/scripts/make_rtp_workflow.py
@@ -25,7 +25,7 @@ REDIS_HOST = "redishost"
 REDIS_PORT = 6379
 STORAGE_LOCATION = "/mnt/sn1"
 WORKFLOW_CONFIG = (
-    "/home/obs/src/hera_pipelines/pipelines/h4c/rtp/v1/h4c_rtp_stage_1.toml"
+    "/home/obs/src/hera_pipelines/pipelines/h5c/rtp/v1/h5c_rtp_stage_1.toml"
 )
 CONDA_ENV = "RTP"
 ALLOWED_TAGS = ["engineering", "science"]

--- a/scripts/make_rtp_workflow.py
+++ b/scripts/make_rtp_workflow.py
@@ -99,7 +99,7 @@ while True:
             try:
                 with db.sessionmaker() as session:
                     session.add_rtp_process_event(
-                        time=Time.now(), obsid=obsid, event="queued"
+                        time=Time.now(), obsid=obsid, task_name="SETUP", event="queued"
                     )
             except (IntegrityError, UniqueViolation):
                 continue


### PR DESCRIPTION
This PR adds the ability to include job resource info in Slurm. The addition has to be done at the wrapper script level to get the correspondence between OPM task and Slurm jobid. These changes seem to be working on site.