### PR TITLE
Make changes for Slurm at NRAO

### DIFF
--- a/hera_opm/mf_tools.py
+++ b/hera_opm/mf_tools.py
@@ -319,7 +319,7 @@ def process_batch_options(
     ncpu=None,
     mail_user="youremail@example.org",
     queue="hera",
-    batch_system="pbs",
+    batch_system="slurm",
     extra_options=None,
 ):
     """Form a series of batch options to be passed to makeflow.
@@ -357,7 +357,7 @@ def process_batch_options(
 
     """
     if batch_system is None:
-        batch_system = "pbs"
+        batch_system = "slurm"
     if batch_system.lower() == "pbs":
         batch_options = "-l vmem={0:d}M,mem={0:d}M".format(mem)
         if ncpu is not None:

--- a/scripts/makeflow_nrao.sh
+++ b/scripts/makeflow_nrao.sh
@@ -36,7 +36,7 @@ fi
 # actually run makeflow
 # test to see if we have a second argument (number of jobs to submit simultaneously)
 if [ "$#" -gt 1 ]; then
-    makeflow -T torque -J "${2}" "${1}"
+    makeflow -T slurm -J "${2}" "${1}"
 else
-    makeflow -T torque "${1}"
+    makeflow -T slurm "${1}"
 fi


### PR DESCRIPTION
Now that the NRAO scheduler is Slurm instead of PBS, we have made changes to the script that launches makeflow at NRAO to reflect this fact. We have also changed the default scheduling system from PBS -> Slurm, in light of the fact that we no longer use PBS anywhere.

Fixes #130.