### PR TITLE
Write toml

### DIFF
--- a/hera_opm/mf_tools.py
+++ b/hera_opm/mf_tools.py
@@ -12,7 +12,7 @@ import subprocess
 import warnings
 import glob
 import toml
-
+import math
 
 def get_jd(filename):
     """Get the JD from a data file name.
@@ -80,7 +80,7 @@ def _interpolate_config(config, entry):
 
 
 def get_config_entry(
-    config, header, item, required=True, interpolate=True, total_length=1
+    config, header, item, required=True, interpolate=True, total_length=1, default=None
 ):
     """Extract a specific entry from config file.
 
@@ -131,7 +131,7 @@ def get_config_entry(
         return entries
     except KeyError:
         if not required:
-            return None
+            return default
         else:
             raise AssertionError(
                 'Error processing config file: item "{0}" under header "{1}" is '
@@ -1449,6 +1449,10 @@ def build_lstbin_makeflow_from_config(
             lst_start = float(
                 get_config_entry(config, "LSTBIN_OPTS", "lst_start", required=True)
             )
+            lst_width = get_config_entry(
+                config, "LSTBIN_OPTS", "lst_width", required=False, default=2*math.pi
+            )
+
             ntimes_per_file = int(
                 get_config_entry(
                     config, "LSTBIN_OPTS", "ntimes_per_file", required=True
@@ -1464,6 +1468,7 @@ def build_lstbin_makeflow_from_config(
                 _datafiles,
                 dlst=dlst,
                 lst_start=lst_start,
+                lst_width=lst_width,
                 ntimes_per_file=ntimes_per_file,
             )
             nfiles = len(output[2])

--- a/hera_opm/mf_tools.py
+++ b/hera_opm/mf_tools.py
@@ -1541,6 +1541,14 @@ def build_lstbin_makeflow_from_config(
             print(line1, file=f)
             print(line2, file=f)
 
+        # Write the toml config to the output directory.
+        outdir = get_config_entry(config, "LSTBIN_OPTS", "outdir", required=True)
+        shutil.copy2(config_file, outdir + '/lstbin-config.toml')
+
+        # Also write the conda_env export to the LSTbin dir
+        if conda_env is not None:
+            os.system(f"conda env export -n {conda_env} --file {outdir}/environment.yaml")
+
     return
 
 


### PR DESCRIPTION
This PR writes out the configuration TOML and the environment.yaml to the LST bin output directory automatically on building the makeflow. This is useful because often you'll run your makeflow for a given toml, then you'll go and edit the toml to do some other analysis, and all of a sudden you've lost access to the configuration options that went into the LST binned files. This puts the toml file *with* the output files, so it's much harder to lose that information.