### PR TITLE
Pipeline status script improvements

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: set up Python ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
+          miniforge-variant: Miniforge3
           miniforge-version: latest
           use-mamba: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -18,17 +18,19 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
 
     steps:
-      - uses: actions/checkout@v2
-
-      - name: set up Python ${{ matrix.python-version }}
-        uses: conda-incubator/setup-miniconda@v3
+      - uses: actions/checkout@v3
         with:
-          miniforge-variant: Mambaforge
-          miniforge-version: latest
-          use-mamba: true
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
           python-version: ${{ matrix.python-version }}
-          environment-file: ci/test_environment.yml
-          activate-environment: hera_opm_tests
+
+      - name: Install
+        run: |
+          pip install --upgrade pip
+          pip install .[dev]
 
       - name: Conda Info
         run: |

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -18,10 +18,10 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: set up Python ${{ matrix.python-version }}
-        uses: conda-incubator/setup-miniconda@v3
+        uses: actions/setup-python@v4
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -18,19 +18,17 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
 
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v2
 
-      - name: Setup Python
-        uses: actions/setup-python@v4
+      - name: set up Python ${{ matrix.python-version }}
+        uses: conda-incubator/setup-miniconda@v3
         with:
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          use-mamba: true
           python-version: ${{ matrix.python-version }}
-
-      - name: Install
-        run: |
-          pip install --upgrade pip
-          pip install .[dev]
+          environment-file: ci/test_environment.yml
+          activate-environment: hera_opm_tests
 
       - name: Conda Info
         run: |

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: set up Python ${{ matrix.python-version }}
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest

--- a/scripts/pipeline_status.py
+++ b/scripts/pipeline_status.py
@@ -167,7 +167,7 @@ def inspect_log_files(log_files, out_files):
 
     return (
         average_runtime,
-        np.sum(runtimes) / 60.0,
+        np.sum(runtimes[runtimes > 0]) / 60.0,
         np.sum(runtimes == -1),
         len(errored_logs),
         len(timed_out_logs),

--- a/scripts/pipeline_status.py
+++ b/scripts/pipeline_status.py
@@ -223,9 +223,11 @@ for job in workflow:
             logged += glob.glob(os.path.join(wdir, "*." + job + ".*log*"))
             done += glob.glob(os.path.join(wdir, "*." + job + ".*out"))
     logged = filter_errors(logged)
-    average_runtime, total_runtime, nRunning, nErrored, nTimedOut = inspect_log_files(logged, done)
+    average_runtime, total_runtime, nRunning, nErrored, nTimedOut = inspect_log_files(
+        logged, done
+    )
 
     print(f"Average per-job (non-trivial) runtime: {average_runtime:.2f} minutes")
     print(f"Total runtime: {total_runtime:.2f} hours")
-    print(f'{len(total)}\t|\t{len(done)}\t|\t{nRunning}\t|\t{nErrored}\t|\t{nTimedOut}')
+    print(f"{len(total)}\t|\t{len(done)}\t|\t{nRunning}\t|\t{nErrored}\t|\t{nTimedOut}")
     print("total\t|\tdone\t|\trunning\t|\terrored\t|\ttimed out\n\n")

--- a/scripts/pipeline_status.py
+++ b/scripts/pipeline_status.py
@@ -120,9 +120,16 @@ def inspect_log_files(log_files, out_files):
     errored_logs = []
     timed_out_logs = []
     for log_file in log_files:
-        with open(log_file, "r") as f:
-            log_lines = f.readlines()
-        runtimes.append(elapsed_time(log_lines))
+        with open(log_file, "rb") as f:
+            first_line = f.readline().decode(errors="ignore")
+            try:
+                # Seek to the end and back up a bit to catch the last line
+                f.seek(-64, os.SEEK_END)
+            except:
+                # If that fails, read the whole file
+                f.seek(0)
+            last_line = f.readlines()[-1].decode(errors="ignore")
+        runtimes.append(elapsed_time(first_line, last_line))
 
         # It timed out
         if (

--- a/scripts/pipeline_status.py
+++ b/scripts/pipeline_status.py
@@ -125,7 +125,7 @@ def inspect_log_files(log_files, out_files):
             try:
                 # Seek to the end and back up a bit to catch the last line
                 f.seek(-64, os.SEEK_END)
-            except:
+            except OSError:
                 # If that fails, read the whole file
                 f.seek(0)
             last_line = f.readlines()[-1].decode(errors="ignore")
@@ -145,6 +145,8 @@ def inspect_log_files(log_files, out_files):
             if error_warned:
                 print("Errors also suspected in", log_file)
             else:
+                with open(log_file, "r") as f:
+                    log_lines = f.readlines()
                 print("\n\nError Suspected (no .out found) in", log_file)
                 print("------------------------------------------------\n")
                 print("".join(log_lines))


### PR DESCRIPTION
A few small quality of life improvements to the pipeline status script:

1) Increase speed by not reading whole log files when we don't have to.

2) Also print total runtime (in hours) per process to help better estimate total time for tasks that are expensive for some files and trivial for others.

I also had to update the github actions yaml, since Mambaforge is being deprecated in favor of Miniforge apparently