### PR TITLE
Add new makeflow_type: `lstbin_single_baseline`

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9, "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}

--- a/hera_opm/mf_tools.py
+++ b/hera_opm/mf_tools.py
@@ -1347,7 +1347,7 @@ def build_lstbin_single_baseline_makeflow_from_config(
 ):
     """Construct a makeflow file for LST-binning single-baseline files from a config file.
     Thin wrapper around build_analysis_makeflow_from_config() that handles getting baseline
-    strings like "0_1" to use instead of obsids to help parallelize over files. 
+    strings like "0_1" to use instead of obsids to help parallelize over files.
 
     Parameters
     ----------

--- a/hera_opm/mf_tools.py
+++ b/hera_opm/mf_tools.py
@@ -1347,7 +1347,7 @@ def build_lstbin_single_baseline_makeflow_from_config(
 ):
     """Construct a makeflow file for LST-binning single-baseline files from a config file.
     Thin wrapper around build_analysis_makeflow_from_config() that handles getting baseline
-    strings like "0_1" to use instead of obsids to help parlellize over files. 
+    strings like "0_1" to use instead of obsids to help parlellize over files.
 
     Parameters
     ----------
@@ -1371,7 +1371,9 @@ def build_lstbin_single_baseline_makeflow_from_config(
     # ignore warnings about baseline_strings not being parsable as JDs
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message=".*Unable to figure out the JD.*")
-        build_analysis_makeflow_from_config(baseline_strings, config_file, mf_name=mf_name, work_dir=work_dir)
+        build_analysis_makeflow_from_config(
+            baseline_strings, config_file, mf_name=mf_name, work_dir=work_dir
+        )
 
 
 def make_lstbin_config_file(

--- a/hera_opm/mf_tools.py
+++ b/hera_opm/mf_tools.py
@@ -1347,7 +1347,7 @@ def build_lstbin_single_baseline_makeflow_from_config(
 ):
     """Construct a makeflow file for LST-binning single-baseline files from a config file.
     Thin wrapper around build_analysis_makeflow_from_config() that handles getting baseline
-    strings like "0_1" to use instead of obsids to help parlellize over files.
+    strings like "0_1" to use instead of obsids to help parallelize over files. 
 
     Parameters
     ----------

--- a/hera_opm/tests/test_mf_tools.py
+++ b/hera_opm/tests/test_mf_tools.py
@@ -1190,6 +1190,7 @@ def test_build_analysis_makeflow_error_obsid_list(config_options):
 
     return
 
+
 @pytest.fixture()
 def tmp_cfg_dir(tmp_path: Path) -> Path:
     """
@@ -1203,7 +1204,7 @@ def tmp_cfg_dir(tmp_path: Path) -> Path:
       ├── do_LST_STACK_NOTEBOOK_SINGLE_BL.sh
       └── cfg.toml
     """
-    nights    = ["2459861", "2459862"]
+    nights = ["2459861", "2459862"]
     baselines = ["0_1", "1_2"]
 
     # 1) fake “do_” script
@@ -1272,7 +1273,8 @@ def test_wrapper_scripts_single_baseline(tmp_cfg_dir: Path):
 
     # Wrapper names use the pattern  "<baseline>.<ACTION>.sh"
     expected = {
-        work_dir / f"wrapper_{bl}.LST_STACK_NOTEBOOK_SINGLE_BL.sh" for bl in ("0_1", "1_2")
+        work_dir / f"wrapper_{bl}.LST_STACK_NOTEBOOK_SINGLE_BL.sh"
+        for bl in ("0_1", "1_2")
     }
     missing = {p for p in expected if not p.exists()}
     assert not missing, f"missing wrapper scripts: {missing}"

--- a/hera_opm/tests/test_mf_tools.py
+++ b/hera_opm/tests/test_mf_tools.py
@@ -8,8 +8,6 @@ import shutil
 import gzip
 import toml
 from pathlib import Path
-import sys
-import types
 
 from . import BAD_CONFIG_PATH
 from ..data import DATA_PATH

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ long_description_content_type = text/markdown
 
 [options.extras_require]
 test =
-    hera-calibration>=3.3.0
+    hera-calibration>=3.7.5
     pytest
     pytest-cov
 package =


### PR DESCRIPTION
This PR adds support for a new makeflow_type, `lstbin_single_baseline`, designed for LST-stacking files that have one baseline (generally for all 2 or 4 pols) for all times on a given JD. This is a thin wrapper around the `analysis` type, using baseline strings like `1_2` instead of JD strings as "obsids"... which seems to work just fine. 

The advantage of this, as opposed to modifying the lstbin type is that this currently supports workflows with multiple actions (which I think I'll need). Also, single-baseline LST stacking is fundamentally more similar to analysis types, where existing files are the base object on which we'd like to parallelize, rather than an abstract set of LSTs inferred from the data and the configuration files. 

This PR requires https://github.com/HERA-Team/hera_cal/pull/1005 to be merged first.
