### PR TITLE
Use --cpus-per-task for SLURM CPU option

### DIFF
--- a/hera_opm/mf_tools.py
+++ b/hera_opm/mf_tools.py
@@ -377,7 +377,7 @@ def process_batch_options(
     elif batch_system.lower() == "slurm":
         batch_options = "--mem {:d}M".format(mem)
         if ncpu is not None:
-            batch_options += " -n {:d}".format(ncpu)
+            batch_options += " --cpus-per-task {:d}".format(ncpu)
         if mail_user is not None:
             batch_options += " --mail-user {}".format(mail_user)
         if queue is not None:

--- a/hera_opm/tests/test_mf_tools.py
+++ b/hera_opm/tests/test_mf_tools.py
@@ -318,7 +318,7 @@ def test_process_batch_options_slurm():
         mem, ncpu, mail_user, queue, batch_system, extra_options
     )
     assert "--mem 8000M" in batch_options
-    assert "-n 1" in batch_options
+    assert "--cpus-per-task 1" in batch_options
     assert "--mail-user youremail@example.org" in batch_options
     assert "-p hera" in batch_options
     assert "--gres=gpu" in batch_options


### PR DESCRIPTION
Replace the short -n flag with SLURM's --cpus-per-task when specifying ncpu in process_batch_options to correctly request CPUs per task (rather than number of tasks). Update the corresponding unit test to expect --cpus-per-task. (-n is -ntasks and the option we actually wanted is -c, but this is more explicit.)